### PR TITLE
Support for RHEL/CentOS 7 which uses FHS-3.0. 

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -78,6 +78,10 @@ class nginx::params {
 
   $nx_pid = $::kernel ? {
     /(?i-mx:linux)/   => $::osfamily ? {
+        /(?i-mx:redhat)/ => $::operatingsystemmajrelease ? {
+            /7/     => '/run/nginx.pid',
+            default => '/var/run/nginx.pid',
+        },
         # archlinux has hardcoded pid in service file to /run/nginx.pid, setting
         # it will prevent nginx from starting
         /(?i-mx:archlinux)/ => false,

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -141,6 +141,7 @@ define nginx::resource::location (
   $proxy_connect_timeout = $nginx::config::proxy_connect_timeout,
   $proxy_set_header     = $nginx::config::proxy_set_header,
   $fastcgi              = undef,
+  $fastcgi_index        = undef,
   $fastcgi_param        = undef,
   $fastcgi_params       = "${nginx::config::conf_dir}/fastcgi_params",
   $fastcgi_script       = undef,

--- a/templates/vhost/locations/fastcgi.erb
+++ b/templates/vhost/locations/fastcgi.erb
@@ -1,6 +1,9 @@
 <% if defined? @www_root -%>
     root  <%= @www_root %>;
 <% end -%>
+<% if defined? @fastcgi_index -%>
+    fastcgi_index <%= @fastcgi_index %>;
+<% end -%>
 <% if @fastcgi_split_path -%>
     fastcgi_split_path_info <%= @fastcgi_split_path %>;
 <% end -%>


### PR DESCRIPTION
FHS-3.0 dictates that pid files lives in /run.

NB. This is a suggestion for a change. If the code I have written does not fit well feel free to change it around or suggest changes.