### PR TITLE
Fixing default location to use specified index files.

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -501,7 +501,7 @@ define nginx::resource::vhost (
       try_files             => $try_files,
       www_root              => $www_root,
       autoindex             => $autoindex,
-      index_files           => [],
+      index_files           => $index_files,
       location_custom_cfg   => $location_custom_cfg,
       notify                => Class['::nginx::service'],
       rewrite_rules         => $rewrite_rules,


### PR DESCRIPTION
The comments indicate that `index_files` set on the vhost is used for the default location, but it doesn't currently do that. This pull fixes that.