### PR TITLE
metadata: require puppetlabs-stdlib 4.2.0 and up

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/jfryman/puppet-nginx/issues",
   "description": "This module can be used for basic NGINX Management",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 3.0.0 <5.0.0"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.2.0 <5.0.0"},
     {"name":"puppetlabs/apt","version_requirement":">= 1.0.0 <2.0.0"},
     {"name":"puppetlabs/concat","version_requirement":">= 1.1.1 <2.0.0"}
   ],


### PR DESCRIPTION
Required as of c87744aab94a8fae81669dbffb1d44a48a3f3da1 (#509). Only 4.2.0 and up treats integers in strings as being an integer.

Should push a new version to Forge since anyone on less than 4.2.0 will likely be having trouble.

Fixes #537