### PR TITLE
allow listen_ip and ipv6_listen_ip to contain a String or Array

### DIFF
--- a/manifests/resource/mailhost.pp
+++ b/manifests/resource/mailhost.pp
@@ -74,12 +74,16 @@ define nginx::resource::mailhost (
   }
   validate_re($ensure, '^(present|absent)$',
     "${ensure} is not supported for ensure. Allowed values are 'present' and 'absent'.")
-  validate_string($listen_ip)
+  if !(is_array($listen_ip) or is_string($listen_ip)) {
+    fail('$listen_ip must be a string or array.')
+  }
   if ($listen_options != undef) {
     validate_string($listen_options)
   }
   validate_bool($ipv6_enable)
-  validate_string($ipv6_listen_ip)
+  if !(is_array($ipv6_listen_ip) or is_string($ipv6_listen_ip)) {
+    fail('$ipv6_listen_ip must be a string or array.')
+  }
   if !is_integer($ipv6_listen_port) {
     fail('$ipv6_listen_port must be an integer.')
   }

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -235,7 +235,9 @@ define nginx::resource::vhost (
 
   validate_re($ensure, '^(present|absent)$',
     "${ensure} is not supported for ensure. Allowed values are 'present' and 'absent'.")
-  validate_string($listen_ip)
+  if !(is_array($listen_ip) or is_string($listen_ip)) {
+    fail('$listen_ip must be a string or array.')
+  }
   if !is_integer($listen_port) {
     fail('$listen_port must be an integer.')
   }
@@ -245,7 +247,9 @@ define nginx::resource::vhost (
   validate_array($location_allow)
   validate_array($location_deny)
   validate_bool($ipv6_enable)
-  validate_string($ipv6_listen_ip)
+  if !(is_array($ipv6_listen_ip) or is_string($ipv6_listen_ip)) {
+    fail('$ipv6_listen_ip must be a string or array.')
+  }
   if !is_integer($ipv6_listen_port) {
     fail('$ipv6_listen_port must be an integer.')
   }

--- a/spec/defines/resource_mailhost_spec.rb
+++ b/spec/defines/resource_mailhost_spec.rb
@@ -209,29 +209,29 @@ describe 'nginx::resource::mailhost' do
           :title => 'should set the IPv4 SSL listen port',
           :attr  => 'ssl_port',
           :value => '45',
-          :match => '  listen       45;',
+          :match => '  listen       *:45;',
         },
         {
           :title => 'should enable IPv6',
           :attr  => 'ipv6_enable',
           :value => true,
-          :match => '  listen [::]:80 default ipv6only=on;',
+          :match => '  listen [::]:587 default ipv6only=on;',
         },
         {
           :title    => 'should not enable IPv6',
           :attr     => 'ipv6_enable',
           :value    => false,
-          :notmatch => /  listen \[::\]:80 default ipv6only=on;/,
+          :notmatch => /  listen \[::\]:587 default ipv6only=on;/,
         },
         {
           :title => 'should set the IPv6 listen IP',
           :attr  => 'ipv6_listen_ip',
           :value => '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
-          :match => '  listen [2001:0db8:85a3:0000:0000:8a2e:0370:7334]:80 default ipv6only=on;',
+          :match => '  listen [2001:0db8:85a3:0000:0000:8a2e:0370:7334]:587 default ipv6only=on;',
         },
         {
-          :title => 'should set the IPv6 listen port',
-          :attr  => 'ipv6_listen_port',
+          :title => 'should set the IPv6 ssl port',
+          :attr  => 'ssl_port',
           :value => 45,
           :match => '  listen [::]:45 default ipv6only=on;',
         },
@@ -239,7 +239,7 @@ describe 'nginx::resource::mailhost' do
           :title => 'should set the IPv6 listen options',
           :attr  => 'ipv6_listen_options',
           :value => 'spdy',
-          :match => '  listen [::]:80 spdy;',
+          :match => '  listen [::]:587 spdy;',
         },
         {
           :title => 'should set servername(s)',
@@ -281,6 +281,7 @@ describe 'nginx::resource::mailhost' do
         context "when #{param[:attr]} is #{param[:value]}" do
           let :default_params do {
             :listen_port => 25,
+            :ssl_port    => 587,
             :ipv6_enable => true,
             :ssl         => true,
             :ssl_cert    => 'dummy.crt',

--- a/spec/defines/resource_vhost_spec.rb
+++ b/spec/defines/resource_vhost_spec.rb
@@ -51,7 +51,6 @@ describe 'nginx::resource::vhost' do
           :value    => false,
           :notmatch => %r|
             ^
-            \s+listen\s+\*:80;\n
             \s+server_name\s+www\.rspec\.example\.com;\n
             \s+return\s+301\s+http://rspec\.example\.com\$uri;
           |x,
@@ -62,7 +61,6 @@ describe 'nginx::resource::vhost' do
           :value => true,
           :match => %r|
             ^
-            \s+listen\s+\*:80;\n
             \s+server_name\s+www\.rspec\.example\.com;\n
             \s+return\s+301\s+http://rspec\.example\.com\$uri;
           |x,
@@ -274,7 +272,6 @@ describe 'nginx::resource::vhost' do
           :value    => false,
           :notmatch => %r|
             ^
-            \s+listen\s+\*:443\s+ssl;\n
             \s+server_name\s+www\.rspec\.example\.com;\n
             \s+return\s+301\s+https://rspec\.example\.com\$uri;
           |x,
@@ -339,7 +336,6 @@ describe 'nginx::resource::vhost' do
           :value    => false,
           :notmatch => %r|
             ^
-            \s+listen\s+\*:443\s+ssl;\n
             \s+server_name\s+www\.rspec\.example\.com;\n
             \s+return\s+301\s+https://rspec\.example\.com\$uri;
           |x,
@@ -350,7 +346,6 @@ describe 'nginx::resource::vhost' do
           :value => true,
           :match => %r|
             ^
-            \s+listen\s+\*:443\s+ssl;\n
             \s+server_name\s+www\.rspec\.example\.com;\n
             \s+return\s+301\s+https://rspec\.example\.com\$uri;
           |x,
@@ -595,7 +590,6 @@ describe 'nginx::resource::vhost' do
           :value    => false,
           :notmatch => %r|
             ^
-            \s+listen\s+\*:443\s+ssl;\n
             \s+server_name\s+www\.rspec\.example\.com;\n
             \s+return\s+301\s+https://rspec\.example\.com\$uri;
           |x,

--- a/templates/mailhost/mailhost.erb
+++ b/templates/mailhost/mailhost.erb
@@ -1,10 +1,22 @@
 
 server {
+<%- if @listen_ip.is_a?(Array) then -%>
+  <%- @listen_ip.each do |ip| -%>
+  listen                <%= ip %>:<%= @listen_port %><% if @listen_options %> <%= @listen_options %><% end %>;
+  <%- end -%>
+<%- else -%>
   listen                <%= @listen_ip %>:<%= @listen_port %><% if @listen_options %> <%= @listen_options %><% end %>;
-  <% # check to see if ipv6 support exists in the kernel before applying %>
-  <% if @ipv6_enable && (defined? @ipaddress6) %>
-  listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
-  <% end %>
+<%- end -%>
+<%# check to see if ipv6 support exists in the kernel before applying -%>
+<%- if @ipv6_enable && (defined? @ipaddress6) -%>
+  <%- if @ipv6_listen_ip.is_a?(Array) then -%>
+    <%- @ipv6_listen_ip.each do |ipv6| -%>
+  listen [<%= ipv6 %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
+    <%- end -%>
+  <%- else -%>
+  listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
+  <%- end -%>
+<%- end -%>
   server_name           <%= @server_name.join(" ") %>;
   protocol              <%= @protocol %>;
   xclient               <%= @xclient %>;

--- a/templates/mailhost/mailhost_ssl.erb
+++ b/templates/mailhost/mailhost_ssl.erb
@@ -1,10 +1,22 @@
 
 server {
-  listen       <%= @ssl_port %>;
-  <% # check to see if ipv6 support exists in the kernel before applying %>
-  <% if @ipv6_enable && (defined? @ipaddress6) %>
-  listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
-  <% end %>
+<%- if @listen_ip.is_a?(Array) then -%>
+  <%- @listen_ip.each do |ip| -%>
+  listen       <%= ip %>:<%= @ssl_port %>;
+  <%- end -%>
+<%- else -%>
+  listen       <%= @listen_ip %>:<%= @ssl_port %>;
+<%- end -%>
+<%# check to see if ipv6 support exists in the kernel before applying -%>
+<%- if @ipv6_enable && (defined? @ipaddress6) -%>
+  <%- if @ipv6_listen_ip.is_a?(Array) then -%>
+    <%- @ipv6_listen_ip.each do |ipv6| -%>
+  listen [<%= ipv6 %>]:<%= @ssl_port %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
+    <%- end -%>
+  <%- else -%>
+  listen [<%= @ipv6_listen_ip %>]:<%= @ssl_port %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
+  <%- end -%>
+<%- end -%>
   server_name           <%= @server_name.join(" ") %>;
   protocol              <%= @protocol %>;
   xclient               <%= @xclient %>;

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -1,20 +1,48 @@
 <% if @rewrite_www_to_non_www -%>
 server {
-  listen       <%= @listen_ip %>:<%= @listen_port %>;
+  <%- if @listen_ip.is_a?(Array) then -%>
+    <%- @listen_ip.each do |ip| -%>
+  listen       <%= ip %>:<%= @listen_port %><% if @listen_options %> <%= @listen_options %><% end %>;
+    <%- end -%>
+  <%- else -%>
+  listen       <%= @listen_ip %>:<%= @listen_port %><% if @listen_options %> <%= @listen_options %><% end %>;
+  <%- end -%>
+<%# check to see if ipv6 support exists in the kernel before applying -%>
+  <%- if @ipv6_enable && (defined? @ipaddress6) -%>
+    <%- if @ipv6_listen_ip.is_a?(Array) then -%>
+      <%- @ipv6_listen_ip.each do |ipv6| -%>
+  listen [<%= ipv6 %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
+      <%- end -%>
+    <%- else -%>
+  listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
+    <%- end -%>
+  <%- end -%>
   server_name  www.<%= @server_name[0].gsub(/^www\./, '') %>;
   return       301 http://<%= @server_name[0].gsub(/^www\./, '') %>$uri;
 }
 
 <% end -%>
 server {
-  listen                <%= @listen_ip %>:<%= @listen_port %><% if @listen_options %> <%= @listen_options %><% end %>;
+<%- if @listen_ip.is_a?(Array) then -%>
+  <%- @listen_ip.each do |ip| -%>
+  listen <%= ip %>:<%= @listen_port %><% if @listen_options %> <%= @listen_options %><% end %>;
+  <%- end -%>
+<%- else -%>
+  listen <%= @listen_ip %>:<%= @listen_port %><% if @listen_options %> <%= @listen_options %><% end %>;
+<%- end -%>
 <%# check to see if ipv6 support exists in the kernel before applying -%>
-<% if @ipv6_enable && (defined? @ipaddress6) -%>
+<%- if @ipv6_enable && (defined? @ipaddress6) -%>
+  <%- if @ipv6_listen_ip.is_a?(Array) then -%>
+    <%- @ipv6_listen_ip.each do |ipv6| -%>
+  listen [<%= ipv6 %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
+    <%- end -%>
+  <%- else -%>
   listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
-<% end -%>
+  <%- end -%>
+<%- end -%>
   server_name           <%= @rewrite_www_to_non_www ? @server_name[0].gsub(/^www\./, '') : @server_name.join(" ") %>;
 <%- if instance_variables.any? { |iv| iv.to_s.include? 'auth_basic' } -%>
-  <% if defined? @auth_basic -%>
+  <%- if defined? @auth_basic -%>
   auth_basic           "<%= @auth_basic %>";
   <%- end -%>
   <%- if defined? @auth_basic_user_file -%>

--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -1,15 +1,44 @@
 <% if @rewrite_www_to_non_www -%>
 server {
-  listen       <%= @listen_ip %>:<%= @ssl_port %> ssl;
+  <%- if @listen_ip.is_a?(Array) then -%>
+    <%- @listen_ip.each do |ip| -%>
+  listen       <%= ip %>:<%= @ssl_port %> <% if @ssl_listen_option %>ssl<% end %><% if @spdy == 'on' %> spdy<% end %><% if @listen_options %> <%= @listen_options %><% end %>;
+    <%- end -%>
+  <%- else -%>
+  listen       <%= @listen_ip %>:<%= @ssl_port %> <% if @ssl_listen_option %>ssl<% end %><% if @spdy == 'on' %> spdy<% end %><% if @listen_options %> <%= @listen_options %><% end %>;
+  <%- end -%>
+<%# check to see if ipv6 support exists in the kernel before applying -%>
+  <%- if @ipv6_enable && (defined? @ipaddress6) -%>
+    <%- if @ipv6_listen_ip.is_a?(Array) then -%>
+      <%- @ipv6_listen_ip.each do |ipv6| -%>
+  listen [<%= ipv6 %>]:<%= @ssl_port %> ssl<% if @spdy == 'on' %> spdy<% end %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
+      <%- end -%>
+    <%- else -%>
+  listen       [<%= @ipv6_listen_ip %>]:<%= @ssl_port %> ssl<% if @spdy == 'on' %> spdy<% end %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
+    <%- end -%>
+  <%- end -%>
   server_name  www.<%= @server_name[0].gsub(/^www\./, '') %>;
   return       301 https://<%= @server_name[0].gsub(/^www\./, '') %>$uri;
 }
 
 <% end -%>
 server {
+  <%- if @listen_ip.is_a?(Array) then -%>
+    <%- @listen_ip.each do |ip| -%>
+  listen       <%= ip %>:<%= @ssl_port %> <% if @ssl_listen_option %>ssl<% end %><% if @spdy == 'on' %> spdy<% end %><% if @listen_options %> <%= @listen_options %><% end %>;
+    <%- end -%>
+  <%- else -%>
   listen       <%= @listen_ip %>:<%= @ssl_port %> <% if @ssl_listen_option %>ssl<% end %><% if @spdy == 'on' %> spdy<% end %><% if @listen_options %> <%= @listen_options %><% end %>;
+  <%- end -%>
+<%# check to see if ipv6 support exists in the kernel before applying -%>
   <%- if @ipv6_enable && (defined? @ipaddress6) -%>
-  listen [<%= @ipv6_listen_ip %>]:<%= @ssl_port %> ssl<% if @spdy == 'on' %> spdy<% end %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
+    <%- if @ipv6_listen_ip.is_a?(Array) then -%>
+      <%- @ipv6_listen_ip.each do |ipv6| -%>
+  listen       [<%= ipv6 %>]:<%= @ssl_port %> ssl<% if @spdy == 'on' %> spdy<% end %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
+      <%- end -%>
+    <%- else -%>
+  listen       [<%= @ipv6_listen_ip %>]:<%= @ssl_port %> ssl<% if @spdy == 'on' %> spdy<% end %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
+    <%- end -%>
   <%- end -%>
   server_name  <%= @rewrite_www_to_non_www ? @server_name[0].gsub(/^www\./, '') : @server_name.join(" ") %>;
 


### PR DESCRIPTION
This allows one to pass multiple ipv4/ipv6 addresses to a specific vhost.  I also added ipv6 and a few ssl options to the www redirect block.