### PR TITLE
Allow to use OpenBSD specific service_flags and package_flavors.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -130,13 +130,28 @@ nginx::nginx_mailhosts:
 
 ## Nginx with precompiled Passenger
 
-Currently this works only for Debian family.
+Currently this works only for Debian family and OpenBSD.
 
+On Debian it might look like:
 ```puppet
 class { 'nginx':
   package_source  => 'passenger',
   http_cfg_append => {
     'passenger_root' => '/usr/lib/ruby/vendor_ruby/phusion_passenger/locations.ini',
+  }
+}
+```
+
+Here the example for OpenBSD:
+
+```puppet
+class { 'nginx':
+  package_flavor => 'passenger',
+  service_flags  => '-u'
+  http_cfg_append => {
+    passenger_root          => '/usr/local/lib/ruby/gems/2.1/gems/passenger-4.0.44',
+    passenger_ruby          =>  '/usr/local/bin/ruby21',
+    passenger_max_pool_size => '15',
   }
 }
 ```

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,12 +102,14 @@ class nginx (
   $package_ensure                 = present,
   $package_name                   = $::nginx::params::package_name,
   $package_source                 = 'nginx',
+  $package_flavor                 = undef,
   $manage_repo                    = $::nginx::params::manage_repo,
   ### END Package Configuration ###
 
   ### START Service Configuation ###
   $configtest_enable              = false,
   $service_ensure                 = running,
+  $service_flags                  = undef,
   $service_restart                = '/etc/init.d/nginx configtest && /etc/init.d/nginx restart',
   $service_name                   = undef,
   ### END Service Configuration ###
@@ -210,6 +212,7 @@ class nginx (
     package_name   => $package_name,
     package_source => $package_source,
     package_ensure => $package_ensure,
+    package_flavor => $package_flavor,
     notify         => Class['::nginx::service'],
     manage_repo    => $manage_repo,
   }
@@ -291,6 +294,7 @@ class nginx (
     service_ensure    => $service_ensure,
     service_restart   => $service_restart,
     service_name      => $service_name,
+    service_flags     => $service_flags,
   }
 
   create_resources('::nginx::resource::upstream', $nginx_upstreams)

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -17,6 +17,7 @@ class nginx::package(
   $package_name   = $::nginx::params::package_name,
   $package_source = 'nginx',
   $package_ensure = 'present',
+  $package_flavor = undef,
   $manage_repo    = $::nginx::params::manage_repo,
 ) inherits ::nginx::params {
 
@@ -55,6 +56,12 @@ class nginx::package(
         ensure => $package_ensure,
         name   => $package_name,
         source => $package_source,
+      }
+    }
+    'OpenBSD': {
+      package { $package_name:
+        ensure => $package_ensure,
+        flavor => $package_flavor,
       }
     }
     default: {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -18,6 +18,7 @@ class nginx::service(
   $service_restart   = $::nginx::service_restart,
   $service_ensure    = $::nginx::service_ensure,
   $service_name      = 'nginx',
+  $service_flags     = undef,
 ) {
 
   $service_enable = $service_ensure ? {
@@ -38,6 +39,7 @@ class nginx::service(
     ensure     => $service_ensure_real,
     name       => $service_name,
     enable     => $service_enable,
+    flags      => $service_flags,
     hasstatus  => true,
     hasrestart => true,
   }

--- a/metadata.json
+++ b/metadata.json
@@ -22,6 +22,9 @@
       ]
     },
     {
+      "operatingsystem": "OpenBSD"
+    },
+    {
       "operatingsystem": "RedHat",
       "operatingsystemrelease":[
         "5.0",


### PR DESCRIPTION
Give example for passenger in README.md and add OpenBSD to the
supported OSs in metadata.json.