### PR TITLE
changed $::operatingsystemmajrelease to $::lsbmajdistrelease for Debian

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,7 +20,7 @@ class nginx::params {
     }
     'Debian': {
       if ($::operatingsystem == 'ubuntu' and $::lsbdistcodename in ['lucid', 'precise', 'trusty'])
-      or ($::operatingsystem == 'debian' and $::operatingsystemmajrelease in ['6', '7']) {
+      or ($::operatingsystem == 'debian' and $::lsbmajdistrelease in ['6', '7']) {
         $_module_os_overrides = {
           'manage_repo' => true,
           'daemon_user' => 'www-data',

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -52,10 +52,10 @@ describe 'nginx::package' do
     end
   end
 
-  shared_examples 'debian' do |operatingsystem, lsbdistcodename, lsbdistid, operatingsystemmajrelease|
+  shared_examples 'debian' do |operatingsystem, lsbdistcodename, lsbdistid, lsbmajdistrelease|
     let(:facts) {{
       :operatingsystem => operatingsystem,
-      :operatingsystemmajrelease => operatingsystemmajrelease,
+      :lsbmajdistrelease => lsbmajdistrelease,
       :osfamily        => 'Debian',
       :lsbdistcodename => lsbdistcodename,
       :lsbdistid       => lsbdistid


### PR DESCRIPTION
The fact operatingsystemmajrelease does not exists in facter < 1.7 wich is installed by default on debian wheezy. That comes along with puppet 2.7.23 wich should be supported. The resolution is to use lsbmajdistrelease fact.

I only adopted the code for debian, just to here what you think. If you agree, I would also update the code for redhat etc.