### PR TITLE
Flags parameter supported only on OpenBSD

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -41,7 +41,7 @@ class nginx::service(
         ensure     => $service_ensure_real,
         name       => $service_name,
         enable     => $service_enable,
-        flags      => '',
+        flags      => $service_flags,
         hasstatus  => true,
         hasrestart => true,
       }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -35,14 +35,28 @@ class nginx::service(
     $service_ensure_real = $service_ensure
   }
 
-  service { 'nginx':
-    ensure     => $service_ensure_real,
-    name       => $service_name,
-    enable     => $service_enable,
-    flags      => $service_flags,
-    hasstatus  => true,
-    hasrestart => true,
+  case $::osfamilly {
+    'OpenBSD': {
+      service { 'nginx':
+        ensure     => $service_ensure_real,
+        name       => $service_name,
+        enable     => $service_enable,
+        flags      => '',
+        hasstatus  => true,
+        hasrestart => true,
+      }
+    }
+    default: {
+      service { 'nginx':
+        ensure     => $service_ensure_real,
+        name       => $service_name,
+        enable     => $service_enable,
+        hasstatus  => true,
+        hasrestart => true,
+      }
+    }
   }
+
   if $configtest_enable == true {
     Service['nginx'] {
       restart => $service_restart,


### PR DESCRIPTION
Flags parameter is only supported on OpenBSD and breaks on some other systems like RH (on puppet 3.4.x)
See the discussion here: https://github.com/jfryman/puppet-nginx/commit/2960c10cd