### PR TITLE
update yumrepos to use $releasever

### DIFF
--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -33,7 +33,7 @@ class nginx::package::redhat (
     case $package_source {
       'nginx', 'nginx-stable': {
         yumrepo { 'nginx-release':
-          baseurl  => "http://nginx.org/packages/${_os}/${::operatingsystemmajrelease}/\$basearch/",
+          baseurl  => "http://nginx.org/packages/${_os}/\$releasever/\$basearch/",
           descr    => 'nginx repo',
           enabled  => '1',
           gpgcheck => '1',
@@ -44,7 +44,7 @@ class nginx::package::redhat (
       }
       'nginx-mainline': {
         yumrepo { 'nginx-release':
-          baseurl  => "http://nginx.org/packages/mainline/${_os}/${::operatingsystemmajrelease}/\$basearch/",
+          baseurl  => "http://nginx.org/packages/mainline/${_os}/\$releasever/\$basearch/",
           descr    => 'nginx repo',
           enabled  => '1',
           gpgcheck => '1',


### PR DESCRIPTION
The yum team introduced this feature several years ago and it is currently their prefered way for setting up the release number