### PR TITLE
Prepend to the nginx config block

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -62,6 +62,7 @@ class nginx::config(
   $multi_accept                   = 'off',
   $names_hash_bucket_size         = '64',
   $names_hash_max_size            = '512',
+  $nginx_cfg_prepend              = false,
   $proxy_buffers                  = '32 4k',
   $proxy_buffer_size              = '8k',
   $proxy_cache_inactive           = '20m',
@@ -148,6 +149,12 @@ class nginx::config(
   if ($http_cfg_append != false) {
     if !(is_hash($http_cfg_append) or is_array($http_cfg_append)) {
       fail('$http_cfg_append must be either a hash or array')
+    }
+  }
+
+  if ($nginx_cfg_prepend != false) {
+    if !(is_hash($nginx_cfg_prepend) or is_array($nginx_cfg_prepend)) {
+      fail('$nginx_cfg_prepend must be either a hash or array')
     }
   }
 

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -165,6 +165,35 @@ describe 'nginx::config' do
           ],
         },
         {
+          :title => 'should contain ordered appended directives from hash',
+          :attr  => 'nginx_cfg_prepend',
+          :value => { 'test1' => 'test value 1', 'test2' => 'test value 2', 'allow' => 'test value 3' },
+          :match => [
+            'allow test value 3;',
+            'test1 test value 1;',
+            'test2 test value 2;',
+          ],
+        },
+        {
+          :title => 'should contain duplicate appended directives from list of hashes',
+          :attr  => 'nginx_cfg_prepend',
+          :value => [[ 'allow', 'test value 1'], ['allow', 'test value 2' ]],
+          :match => [
+            'allow test value 1;',
+            'allow test value 2;',
+          ],
+        },
+        {
+          :title => 'should contain duplicate appended directives from array values',
+          :attr  => 'nginx_cfg_prepend',
+          :value => { 'test1' => ['test value 1', 'test value 2', 'test value 3'] },
+          :match => [
+            'test1 test value 1;',
+            'test1 test value 2;',
+            'test1 test value 3;',
+          ],
+        },
+        {
             :title => 'should set pid',
             :attr  => 'pid',
             :value => '/path/to/pid',

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -11,6 +11,15 @@ pid        <%= @pid %>;
 <% end -%>
 error_log  <%= @nginx_error_log %>;
 
+<% if @nginx_cfg_prepend -%>
+  <%- field_width = @nginx_cfg_prepend.inject(0) { |l,(k,v)| k.size > l ? k.size : l } -%>
+  <%- @nginx_cfg_prepend.sort_by{|k,v| k}.each do |key,value| -%>
+    <%- Array(value).each do |asubvalue| -%>
+      <%= sprintf("%-*s", field_width, key) %> <%= asubvalue %>;
+    <%- end -%>
+  <%- end -%>
+<% end -%>
+
 events {
   worker_connections <%= @worker_connections -%>;
   <%- if @multi_accept == 'on' -%>

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -12,12 +12,12 @@ pid        <%= @pid %>;
 error_log  <%= @nginx_error_log %>;
 
 <% if @nginx_cfg_prepend -%>
-  <%- field_width = @nginx_cfg_prepend.inject(0) { |l,(k,v)| k.size > l ? k.size : l } -%>
-  <%- @nginx_cfg_prepend.sort_by{|k,v| k}.each do |key,value| -%>
-    <%- Array(value).each do |asubvalue| -%>
-      <%= sprintf("%-*s", field_width, key) %> <%= asubvalue %>;
-    <%- end -%>
-  <%- end -%>
+<%- field_width = @nginx_cfg_prepend.inject(0) { |l,(k,v)| k.size > l ? k.size : l } -%>
+<%- @nginx_cfg_prepend.sort_by{|k,v| k}.each do |key,value| -%>
+<%- Array(value).each do |asubvalue| -%>
+<%= sprintf("%-*s", field_width, key) %> <%= asubvalue %>;
+<%- end -%>
+<%- end -%>
 <% end -%>
 
 events {


### PR DESCRIPTION
#### What's this PR do?
Adds functionality and tests for prepending key/value pairs to the top of the nginx configuration. Tests mimicking the http_cfg_append tests have been added since this functionality is identical albeit in a different place. All rspec tests are currently passing. Furthermore, this change is currently working on a CentOS 6.6 (Final) staging box at a client site. I did not add to the README documentation since there doesn't seem to be a good place to put this. Let me know if there is somewhere you want me to add it.

#### Where should the reviewer start?
Begin in the manifests/config.pp file with the $nginx_cfg_prepend variable validation. Then check the templates/conf.d/nginx.conf.erb for the added nginx_cfg_prepend block.

#### How should this be tested?
By running `bundle exec rake spec` for the unit tests. Tests have been added for this change.

#### Any background context you want to provide?
At Railsdog we support several sites that run Nginx/Passenger and Rbenv on RHEL derivatives. One of the requirements is to feed environment variables to the Passenger process via the Nginx config. This is easily accomplished by using http://nginx.org/en/docs/ngx_core_module.html#env. The only issue is that this variable can only occur at the top of the main nginx config block. Figured others could use this feature as well!