### PR TITLE
Phusion changed the directory for passenger

### DIFF
--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -50,7 +50,7 @@ class nginx::package::debian(
       }
       'passenger': {
         apt::source { 'nginx':
-          location          => 'https://oss-binaries.phusionpassenger.com/apt/passenger',
+          location          => 'https://oss-binaries.phusionpassenger.com/apt/passenger/4',
           repos             => 'main',
           key               => '561F9B9CAC40B2F7',
           key_source        => 'https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key.txt',

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -86,7 +86,7 @@ describe 'nginx::package' do
       it { is_expected.to contain_package('nginx') }
       it { is_expected.to contain_package('passenger') }
       it { is_expected.to contain_apt__source('nginx').with(
-        'location'   => 'https://oss-binaries.phusionpassenger.com/apt/passenger',
+        'location'   => 'https://oss-binaries.phusionpassenger.com/apt/passenger/4',
         'repos'      => "main",
         'key'        => '561F9B9CAC40B2F7',
         'key_source' => 'https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key.txt'


### PR DESCRIPTION
I'm assuming this module was always installing passenger 4 previously? Phusion have [changed the location](https://blog.phusion.nl/2015/03/08/passenger-4-apt-repository-now-available/) of the passenger 4 apt repository which breaks installing nginx with passenger.