### PR TITLE
apt::key: puppetlabs-apt check now the full GPG fingerprints.

### DIFF
--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -36,7 +36,7 @@ class nginx::package::debian(
         apt::source { 'nginx':
           location   => "http://nginx.org/packages/${distro}",
           repos      => 'nginx',
-          key        => '7BD9BF62',
+          key        => 'ABF5BD827BD9BF62',
           key_source => 'http://nginx.org/keys/nginx_signing.key',
         }
       }
@@ -44,7 +44,7 @@ class nginx::package::debian(
         apt::source { 'nginx':
           location   => "http://nginx.org/packages/mainline/${distro}",
           repos      => 'nginx',
-          key        => '7BD9BF62',
+          key        => 'ABF5BD827BD9BF62',
           key_source => 'http://nginx.org/keys/nginx_signing.key',
         }
       }
@@ -61,7 +61,7 @@ class nginx::package::debian(
           ensure  => 'present',
           require => Exec['apt_update'],
         }
-        
+
         if $package_name != 'nginx-extras' {
           warning('You must set $package_name to "nginx-extras" to enable Passenger')
         }

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -67,7 +67,7 @@ describe 'nginx::package' do
       it { is_expected.to contain_apt__source('nginx').with(
         'location'   => "http://nginx.org/packages/#{operatingsystem.downcase}",
         'repos'      => 'nginx',
-        'key'        => '7BD9BF62',
+        'key'        => 'ABF5BD827BD9BF62',
         'key_source' => 'http://nginx.org/keys/nginx_signing.key'
       )}
       it { is_expected.to contain_anchor('nginx::package::begin').that_comes_before('Class[nginx::package::debian]') }


### PR DESCRIPTION
Since commit 531ef9 of puppetlabs-apt, the gpg key (apt::key) is
checked, and should use the long format.

This value is validated with a regex enforcing it to only contain valid
hexadecimal characters, be precisely 8 or 16 hexadecimal characters long
and optionally prefixed with 0x for key IDs, or 40 hexadecimal
characters long for key fingerprints.

https://github.com/puppetlabs/puppetlabs-apt/commit/f588f2651a68c5863aac7dac910d96bbc7531ef9

This patch fixes the puppet warning below:

```puppet
Warning: /Apt_key[Add key: 7BD9BF62 from Apt::Source nginx]: The id should be a full fingerprint (40 characters), see README.
```