### PR TITLE
Changing apt key to 40 characters to support new apt module

### DIFF
--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -52,7 +52,7 @@ class nginx::package::debian(
         apt::source { 'nginx':
           location          => 'https://oss-binaries.phusionpassenger.com/apt/passenger',
           repos             => 'main',
-          key               => '561F9B9CAC40B2F7',
+          key               => '16378A33A6EF16762922526E561F9B9CAC40B2F7',
           key_source        => 'https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key.txt',
           required_packages => 'apt-transport-https ca-certificates',
         }

--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -36,7 +36,7 @@ class nginx::package::debian(
         apt::source { 'nginx':
           location   => "http://nginx.org/packages/${distro}",
           repos      => 'nginx',
-          key        => 'ABF5BD827BD9BF62',
+          key        => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62',
           key_source => 'http://nginx.org/keys/nginx_signing.key',
         }
       }
@@ -44,7 +44,7 @@ class nginx::package::debian(
         apt::source { 'nginx':
           location   => "http://nginx.org/packages/mainline/${distro}",
           repos      => 'nginx',
-          key        => 'ABF5BD827BD9BF62',
+          key        => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62',
           key_source => 'http://nginx.org/keys/nginx_signing.key',
         }
       }

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -88,7 +88,7 @@ describe 'nginx::package' do
       it { is_expected.to contain_apt__source('nginx').with(
         'location'   => 'https://oss-binaries.phusionpassenger.com/apt/passenger',
         'repos'      => "main",
-        'key'        => '561F9B9CAC40B2F7',
+        'key'        => '16378A33A6EF16762922526E561F9B9CAC40B2F7',
         'key_source' => 'https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key.txt'
       )}
     end

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -67,7 +67,7 @@ describe 'nginx::package' do
       it { is_expected.to contain_apt__source('nginx').with(
         'location'   => "http://nginx.org/packages/#{operatingsystem.downcase}",
         'repos'      => 'nginx',
-        'key'        => 'ABF5BD827BD9BF62',
+        'key'        => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62',
         'key_source' => 'http://nginx.org/keys/nginx_signing.key'
       )}
       it { is_expected.to contain_anchor('nginx::package::begin').that_comes_before('Class[nginx::package::debian]') }


### PR DESCRIPTION
The new puppetlabs/apt module requires 40 character apt keys or it will spit out warnings. Can you merge this bad boy to master so I can remove the warning?

Thanks,
Erik 