### PR TITLE
Don't allow failures when using the future parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,5 @@ matrix:
       env: PUPPET_GEM_VERSION="~> 2.7.0"
     - rvm: 1.8.7
       env: PUPPET_GEM_VERSION="~> 3.0"
-    - rvm: 2.1.0
-      env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
 notifications:
   email: false  

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,13 @@ matrix:
     - rvm: 2.1.0
       env: PUPPET_GEM_VERSION="~> 3.0"
     - rvm: 2.1.0
-      env: PUPPET_GEM_VERSION="~> 3.5.0" FUTURE_PARSER="yes"
+      env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
   allow_failures:
     - rvm: 1.8.7
       env: PUPPET_GEM_VERSION="~> 2.7.0"
     - rvm: 1.8.7
       env: PUPPET_GEM_VERSION="~> 3.0"
     - rvm: 2.1.0
-      env: PUPPET_GEM_VERSION="~> 3.5.0" FUTURE_PARSER="yes"
+      env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
 notifications:
   email: false  

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :rake, :test do
 end
 
 group :rake do
-  gem 'rspec-puppet', '~>1.0'
+  gem 'rspec-puppet', '>=2',     :require => false
   gem 'rake',         '>=0.9.2.2'
   gem 'puppet-lint',  '>=1.0.1'
   gem 'rspec-system-serverspec', :require => false

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -228,7 +228,7 @@ describe 'nginx::config' do
             if matches.all? { |m| m.is_a? Regexp }
               matches.each { |item| is_expected.to contain_file('/etc/nginx/nginx.conf').with_content(item) }
             else
-              lines = subject.resource('file', '/etc/nginx/nginx.conf').send(:parameters)[:content].split("\n")
+              lines = catalogue.resource('file', '/etc/nginx/nginx.conf').send(:parameters)[:content].split("\n")
               expect(lines & Array(param[:match])).to eq(Array(param[:match]))
             end
 
@@ -298,7 +298,7 @@ describe 'nginx::config' do
             if matches.all? { |m| m.is_a? Regexp }
               matches.each { |item| is_expected.to contain_file('/etc/nginx/conf.d/proxy.conf').with_content(item) }
             else
-              lines = subject.resource('file', '/etc/nginx/conf.d/proxy.conf').send(:parameters)[:content].split("\n")
+              lines = catalogue.resource('file', '/etc/nginx/conf.d/proxy.conf').send(:parameters)[:content].split("\n")
               expect(lines & Array(param[:match])).to eq(Array(param[:match]))
             end
 

--- a/spec/defines/resource_geo_spec.rb
+++ b/spec/defines/resource_geo_spec.rb
@@ -99,7 +99,7 @@ describe 'nginx::resource::geo' do
 
           it { is_expected.to contain_file("/etc/nginx/conf.d/#{title}-geo.conf").with_mode('0644') }
           it param[:title] do
-            verify_contents(subject, "/etc/nginx/conf.d/#{title}-geo.conf", Array(param[:match]))
+            verify_contents(catalogue, "/etc/nginx/conf.d/#{title}-geo.conf", Array(param[:match]))
             Array(param[:notmatch]).each do |item|
               is_expected.to contain_file("/etc/nginx/conf.d/#{title}-geo.conf").without_content(item)
             end

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -162,7 +162,7 @@ describe 'nginx::resource::location' do
             if matches.all? { |m| m.is_a? Regexp }
               matches.each { |item| is_expected.to contain_concat__fragment(fragment).with_content(item) }
             else
-              lines = subject.resource('concat::fragment', fragment).send(:parameters)[:content].split("\n")
+              lines = catalogue.resource('concat::fragment', fragment).send(:parameters)[:content].split("\n")
               expect(lines & matches).to eq(matches)
             end
 
@@ -239,7 +239,7 @@ describe 'nginx::resource::location' do
             if matches.all? { |m| m.is_a? Regexp }
               matches.each { |item| is_expected.to contain_concat__fragment(fragment).with_content(item) }
             else
-              lines = subject.resource('concat::fragment', fragment).send(:parameters)[:content].split("\n")
+              lines = catalogue.resource('concat::fragment', fragment).send(:parameters)[:content].split("\n")
               expect(lines & matches).to eq(matches)
             end
 
@@ -250,7 +250,7 @@ describe 'nginx::resource::location' do
 
           it "should end with a closing brace" do
             fragment = Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")
-            content = subject.resource('concat::fragment', fragment).send(:parameters)[:content]
+            content = catalogue.resource('concat::fragment', fragment).send(:parameters)[:content]
             expect((content.split("\n").reject {|l| l =~ /^(\s*#|$)/ }.last).strip).to eq('}')
           end
         end
@@ -342,7 +342,7 @@ describe 'nginx::resource::location' do
             if matches.all? { |m| m.is_a? Regexp }
               matches.each { |item| is_expected.to contain_concat__fragment(fragment).with_content(item) }
             else
-              lines = subject.resource('concat::fragment', fragment).send(:parameters)[:content].split("\n")
+              lines = catalogue.resource('concat::fragment', fragment).send(:parameters)[:content].split("\n")
               expect(lines & matches).to eq(matches)
             end
 
@@ -403,7 +403,7 @@ describe 'nginx::resource::location' do
             if matches.all? { |m| m.is_a? Regexp }
               matches.each { |item| is_expected.to contain_concat__fragment(fragment).with_content(item) }
             else
-              lines = subject.resource('concat::fragment', fragment).send(:parameters)[:content].split("\n")
+              lines = catalogue.resource('concat::fragment', fragment).send(:parameters)[:content].split("\n")
               expect(lines & matches).to eq(matches)
             end
 
@@ -467,7 +467,7 @@ describe 'nginx::resource::location' do
             if matches.all? { |m| m.is_a? Regexp }
               matches.each { |item| is_expected.to contain_concat__fragment(fragment).with_content(item) }
             else
-              lines = subject.resource('concat::fragment', fragment).send(:parameters)[:content].split("\n")
+              lines = catalogue.resource('concat::fragment', fragment).send(:parameters)[:content].split("\n")
               expect(lines & matches).to eq(matches)
             end
 
@@ -603,7 +603,7 @@ describe 'nginx::resource::location' do
             if matches.all? { |m| m.is_a? Regexp }
               matches.each { |item| is_expected.to contain_concat__fragment(fragment).with_content(item) }
             else
-              lines = subject.resource('concat::fragment', fragment).send(:parameters)[:content].split("\n")
+              lines = catalogue.resource('concat::fragment', fragment).send(:parameters)[:content].split("\n")
               expect(lines & matches).to eq(matches)
             end
 

--- a/spec/defines/resource_mailhost_spec.rb
+++ b/spec/defines/resource_mailhost_spec.rb
@@ -139,7 +139,7 @@ describe 'nginx::resource::mailhost' do
 
           it { is_expected.to contain_concat__fragment("#{title}-header") }
           it param[:title] do
-            lines = subject.resource('concat::fragment', "#{title}-header").send(:parameters)[:content].split("\n")
+            lines = catalogue.resource('concat::fragment', "#{title}-header").send(:parameters)[:content].split("\n")
             expect(lines & Array(param[:match])).to eq(Array(param[:match]))
             Array(param[:notmatch]).each do |item|
               is_expected.to contain_concat__fragment("#{title}-header").without_content(item)
@@ -193,7 +193,7 @@ describe 'nginx::resource::mailhost' do
 
           it { is_expected.to contain_concat__fragment("#{title}-header") }
           it param[:title] do
-            lines = subject.resource('concat::fragment', "#{title}-header").send(:parameters)[:content].split("\n")
+            lines = catalogue.resource('concat::fragment', "#{title}-header").send(:parameters)[:content].split("\n")
             expect(lines & Array(param[:match])).to eq(Array(param[:match]))
             Array(param[:notmatch]).each do |item|
               is_expected.to contain_concat__fragment("#{title}-header").without_content(item)
@@ -291,7 +291,7 @@ describe 'nginx::resource::mailhost' do
 
           it { is_expected.to contain_concat__fragment("#{title}-ssl") }
           it param[:title] do
-            lines = subject.resource('concat::fragment', "#{title}-ssl").send(:parameters)[:content].split("\n")
+            lines = catalogue.resource('concat::fragment', "#{title}-ssl").send(:parameters)[:content].split("\n")
             expect(lines & Array(param[:match])).to eq(Array(param[:match]))
             Array(param[:notmatch]).each do |item|
               is_expected.to contain_concat__fragment("#{title}-ssl").without_content(item)

--- a/spec/defines/resource_map_spec.rb
+++ b/spec/defines/resource_map_spec.rb
@@ -72,7 +72,7 @@ describe 'nginx::resource::map' do
 
           it { is_expected.to contain_file("/etc/nginx/conf.d/#{title}-map.conf").with_mode('0644') }
           it param[:title] do
-            verify_contents(subject, "/etc/nginx/conf.d/#{title}-map.conf", Array(param[:match]))
+            verify_contents(catalogue, "/etc/nginx/conf.d/#{title}-map.conf", Array(param[:match]))
             Array(param[:notmatch]).each do |item|
               is_expected.to contain_file("/etc/nginx/conf.d/#{title}-map.conf").without_content(item)
             end

--- a/spec/defines/resource_upstream_spec.rb
+++ b/spec/defines/resource_upstream_spec.rb
@@ -99,7 +99,7 @@ describe 'nginx::resource::upstream' do
           it { is_expected.to contain_file("/etc/nginx/conf.d/#{title}-upstream.conf").with_mode('0644') }
           it { is_expected.to contain_concat__fragment("#{title}_upstream_#{param[:fragment]}") }
           it param[:title] do
-            lines = subject.resource('concat::fragment', "#{title}_upstream_#{param[:fragment]}").send(:parameters)[:content].split("\n")
+            lines = catalogue.resource('concat::fragment', "#{title}_upstream_#{param[:fragment]}").send(:parameters)[:content].split("\n")
             expect(lines & Array(param[:match])).to eq(Array(param[:match]))
             Array(param[:notmatch]).each do |item|
               is_expected.to contain_concat__fragment("#{title}_upstream_#{param[:fragment]}").without_content(item)

--- a/spec/defines/resource_vhost_spec.rb
+++ b/spec/defines/resource_vhost_spec.rb
@@ -253,7 +253,7 @@ describe 'nginx::resource::vhost' do
             if matches.all? { |m| m.is_a? Regexp }
               matches.each { |item| is_expected.to contain_concat__fragment("#{title}-header").with_content(item) }
             else
-              lines = subject.resource('concat::fragment', "#{title}-header").send(:parameters)[:content].split("\n")
+              lines = catalogue.resource('concat::fragment', "#{title}-header").send(:parameters)[:content].split("\n")
               expect(lines & Array(param[:match])).to eq(Array(param[:match]))
             end
             Array(param[:notmatch]).each do |item|
@@ -317,7 +317,7 @@ describe 'nginx::resource::vhost' do
             if matches.all? { |m| m.is_a? Regexp }
               matches.each { |item| is_expected.to contain_concat__fragment("#{title}-footer").with_content(item) }
             else
-              lines  = subject.resource('concat::fragment', "#{title}-footer").send(:parameters)[:content].split("\n")
+              lines  = catalogue.resource('concat::fragment', "#{title}-footer").send(:parameters)[:content].split("\n")
               expect(lines & Array(param[:match])).to eq(Array(param[:match]))
             end
             Array(param[:notmatch]).each do |item|
@@ -571,7 +571,7 @@ describe 'nginx::resource::vhost' do
             if matches.all? { |m| m.is_a? Regexp }
               matches.each { |item| is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(item) }
             else
-              lines = subject.resource('concat::fragment', "#{title}-ssl-header").send(:parameters)[:content].split("\n")
+              lines = catalogue.resource('concat::fragment', "#{title}-ssl-header").send(:parameters)[:content].split("\n")
               expect(lines & Array(param[:match])).to eq(Array(param[:match]))
             end
             Array(param[:notmatch]).each do |item|
@@ -650,7 +650,7 @@ describe 'nginx::resource::vhost' do
             if matches.all? { |m| m.is_a? Regexp }
               matches.each { |item| is_expected.to contain_concat__fragment("#{title}-ssl-footer").with_content(item) }
             else
-              lines = subject.resource('concat::fragment', "#{title}-ssl-footer").send(:parameters)[:content].split("\n")
+              lines = catalogue.resource('concat::fragment', "#{title}-ssl-footer").send(:parameters)[:content].split("\n")
               expect(lines & Array(param[:match])).to eq(Array(param[:match]))
             end
             Array(param[:notmatch]).each do |item|


### PR DESCRIPTION
Puppet 4 is on the horizon so we don't want to introduce code that's known to be incompatible with it.

Merge #587 before this.