### PR TITLE
Add missing semicolon to custom location settings

### DIFF
--- a/templates/vhost/location_footer.erb
+++ b/templates/vhost/location_footer.erb
@@ -18,12 +18,12 @@
     <%- if value.is_a?(Hash) -%>
       <%- value.sort_by {|k,v| k}.each do |subkey,subvalue| -%>
         <%- Array(subvalue).each do |asubvalue| -%>
-    <%= key %> <%= subkey %> <%= asubvalue %>
+    <%= key %> <%= subkey %> <%= asubvalue %>;
         <%- end -%>
       <%- end -%>
     <%- else -%>
       <%- Array(value).each do |asubvalue| -%>
-    <%= key %> <%= asubvalue %>
+    <%= key %> <%= asubvalue %>;
       <%- end -%>
     <%- end -%>
   <%- end -%>

--- a/templates/vhost/location_header.erb
+++ b/templates/vhost/location_header.erb
@@ -24,12 +24,12 @@
     <%- if value.is_a?(Hash) -%>
       <%- value.sort_by {|k,v| k}.each do |subkey,subvalue| -%>
         <%- Array(subvalue).each do |asubvalue| -%>
-    <%= key %> <%= subkey %> <%= asubvalue %>
+    <%= key %> <%= subkey %> <%= asubvalue %>;
         <%- end -%>
       <%- end -%>
     <%- else -%>
       <%- Array(value).each do |asubvalue| -%>
-    <%= key %> <%= asubvalue %>
+    <%= key %> <%= asubvalue %>;
       <%- end -%>
     <%- end -%>
   <%- end -%>


### PR DESCRIPTION
The custom prepend/append headers in location sections miss the trailing semicolon (as described in issue #308).