### PR TITLE
Allow placement of include files to be a the top or the bottom

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -433,6 +433,9 @@ define nginx::resource::vhost (
     validate_array($include_files)
     validate_bool($include_files_bottom)
     validate_bool($include_files_top)
+    if ($include_files_bottom == $include_files_top) {
+      fail('$include_files_bottom can not be the same as $include_files_top')
+    }
   }
   if ($access_log != undef) {
     validate_string($access_log)

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -431,6 +431,8 @@ define nginx::resource::vhost (
   }
   if ($include_files != undef) {
     validate_array($include_files)
+    validate_bool($include_files_bottom)
+    validate_bool($include_files_top)
   }
   if ($access_log != undef) {
     validate_string($access_log)

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -239,6 +239,8 @@ define nginx::resource::vhost (
   $vhost_cfg_ssl_prepend        = undef,
   $vhost_cfg_ssl_append         = undef,
   $include_files                = undef,
+  $include_files_bottom         = true,
+  $include_files_top            = false,
   $access_log                   = undef,
   $error_log                    = undef,
   $format_log                   = 'combined',

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -127,6 +127,9 @@
 #   [*rewrite_to_https*]        - Adds a server directive and rewrite rule to
 #     rewrite to ssl
 #   [*include_files*]           - Adds include files to vhost
+#   [*include_files_top*]       - Adds include files to vhost at the top
+#   [*include_files_bottom*]    - Adds include files to vhost at the bottom
+#     this is the default behavior
 #   [*access_log*]              - Where to write access log. May add additional
 #     options like log format to the end.
 #   [*error_log*]               - Where to write error log. May add additional

--- a/templates/vhost/vhost_footer.erb
+++ b/templates/vhost/vhost_footer.erb
@@ -1,4 +1,4 @@
-<% if @include_files -%>
+<% if @include_files and @include_files_bottom -%>
   <%- @include_files.each do |file| -%>
   include <%= file %>;
   <%- end -%>

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -49,6 +49,11 @@ server {
   auth_basic_user_file <%= @auth_basic_user_file %>;
   <%- end -%>
 <% end -%>
+<% if @include_files and @include_files_top -%>
+    <%- @include_files.each do |file| -%>
+        include <%= file %>;
+    <%- end -%>
+<%- end -%>
 <% if instance_variables.any? { |iv| iv.to_s.include? 'client_' } -%>
 
   <%- if defined? @client_body_timeout -%>


### PR DESCRIPTION
Its handy at times to have includes run before the rest of the config. So this allows to set them to the top. It defaults to bottom.