### PR TITLE
package/redhat: correct dependency on package

### DIFF
--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -39,7 +39,7 @@ class nginx::package::redhat (
           gpgcheck => '1',
           priority => '1',
           gpgkey   => 'http://nginx.org/keys/nginx_signing.key',
-          before   => Package[$package_name],
+          before   => Package['nginx'],
         }
       }
       'nginx-mainline': {
@@ -50,7 +50,7 @@ class nginx::package::redhat (
           gpgcheck => '1',
           priority => '1',
           gpgkey   => 'http://nginx.org/keys/nginx_signing.key',
-          before   => Package[$package_name],
+          before   => Package['nginx'],
         }
       }
       default: {


### PR DESCRIPTION
When $package_name is not 'nginx' the dependency on the package resource would be incorrect.

Probably never an issue in practice since 'nginx' is the package name in the nginx.org repo, but addresses my OCD