### PR TITLE
gitattributes: add file so all *.pp is recognized as Puppet on Github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pp linguist-language=Puppet


### PR DESCRIPTION
The Github file type detection is not foolproof, and .pp file extension is shared by Pascal.
Sometimes our files are detected as Pascal, not Puppet as they should be.

This change ensures all *.pp files are recognized as Puppet files.

See https://github.com/github/linguist/issues/2318