### PR TITLE
location: make auth_basic_user_file resource unique

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -378,7 +378,7 @@ define nginx::resource::location (
 
   if ($auth_basic_user_file != undef) {
     #Generate htpasswd with provided file-locations
-    file { "${::nginx::config::conf_dir}/${location_sanitized}_htpasswd":
+    file { "${::nginx::config::conf_dir}/${vhost_sanitized}-${location_sanitized}_htpasswd":
       ensure => $ensure_real,
       mode   => '0644',
       source => $auth_basic_user_file,

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -668,7 +668,7 @@ describe 'nginx::resource::location' do
       context 'when auth_basic_user_file => true' do
         let :params do { :auth_basic_user_file => '/path/to/file', :vhost => 'vhost1', :www_root => '/', } end
 
-        it { is_expected.to contain_file("/etc/nginx/rspec-test_htpasswd") }
+        it { is_expected.to contain_file("/etc/nginx/vhost1-rspec-test_htpasswd") }
       end
 
       context 'when ensure => absent' do
@@ -680,7 +680,7 @@ describe 'nginx::resource::location' do
           :auth_basic_user_file => '/path/to/file',
         } end
 
-        it { is_expected.to contain_file("/etc/nginx/rspec-test_htpasswd").with_ensure('absent') }
+        it { is_expected.to contain_file("/etc/nginx/vhost1-rspec-test_htpasswd").with_ensure('absent') }
       end
 
       context "vhost missing" do


### PR DESCRIPTION
Before this change there would be conflicts if multiple vhosts contained locations with the
same name, and those locations set auth_basic_user_file.

Fixes #572 