### PR TITLE
location: move auth_basic directives to header

### DIFF
--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -148,6 +148,18 @@ describe 'nginx::resource::location' do
           :value    => [],
           :notmatch => /rewrite/
         },
+        {
+          :title => 'should set auth_basic',
+          :attr  => 'auth_basic',
+          :value => 'value',
+          :match => '    auth_basic           "value";',
+        },
+        {
+          :title => 'should set auth_basic_user_file',
+          :attr  => 'auth_basic_user_file',
+          :value => 'value',
+          :match => '    auth_basic_user_file value;',
+        },
       ].each do |param|
         context "when #{param[:attr]} is #{param[:value]}" do
           let :default_params do { :location => 'location', :proxy => 'proxy_value', :vhost => 'vhost1' } end
@@ -317,18 +329,6 @@ describe 'nginx::resource::location' do
           :attr  => 'index_files',
           :value => ['name1','name2'],
           :match => '    index     name1 name2;',
-        },
-        {
-          :title => 'should set auth_basic',
-          :attr  => 'auth_basic',
-          :value => 'value',
-          :match => '    auth_basic           "value";',
-        },
-        {
-          :title => 'should set auth_basic_user_file',
-          :attr  => 'auth_basic_user_file',
-          :value => 'value',
-          :match => '    auth_basic_user_file value;',
         },
       ].each do |param|
         context "when #{param[:attr]} is #{param[:value]}" do

--- a/templates/vhost/location_header.erb
+++ b/templates/vhost/location_header.erb
@@ -19,6 +19,12 @@
     deny <%= deny_rule %>;
     <%- end -%>
 <% end -%>
+<% if @auth_basic -%>
+    auth_basic           "<%= @auth_basic %>";
+<%- end %>
+<%- if @auth_basic_user_file -%>
+    auth_basic_user_file <%= @auth_basic_user_file %>;
+<% end -%>
 <% if @location_custom_cfg_prepend -%>
   <%- @location_custom_cfg_prepend.each do |key,value| -%>
     <%- if value.is_a?(Hash) -%>

--- a/templates/vhost/locations/directory.erb
+++ b/templates/vhost/locations/directory.erb
@@ -11,12 +11,3 @@
 <% if @try_files -%>
     try_files<% @try_files.each do |try| -%> <%= try %><% end -%>;
 <% end -%>
-<% if instance_variables.any? { |iv| iv.to_s.include? 'auth_basic' } -%>
-
-    <%- if @auth_basic -%>
-    auth_basic           "<%= @auth_basic %>";
-    <%- end -%>
-    <%- if defined? @auth_basic_user_file -%>
-    auth_basic_user_file <%= @auth_basic_user_file %>;
-    <%- end -%>
-<% end -%>

--- a/templates/vhost/locations/proxy.erb
+++ b/templates/vhost/locations/proxy.erb
@@ -21,12 +21,3 @@
 <% if @proxy_cache_valid -%>
     proxy_cache_valid     <%= @proxy_cache_valid %>;
 <% end -%>
-<% if instance_variables.any? { |iv| iv.to_s.include? 'auth_basic' } -%>
-
-    <%- if @auth_basic -%>
-    auth_basic           "<%= @auth_basic %>";
-    <%- end -%>
-    <%- if defined? @auth_basic_user_file -%>
-    auth_basic_user_file <%= @auth_basic_user_file %>;
-    <%- end -%>
-<% end -%>


### PR DESCRIPTION
Allows setting these directives on any location:
* auth_basic
* auth_basic_user_file

Fixes #600 
Fixes #260 