### PR TITLE
location: remove the auth_basic_user_file resource

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -375,13 +375,4 @@ define nginx::resource::location (
       order   => $ssl_priority,
     }
   }
-
-  if ($auth_basic_user_file != undef) {
-    #Generate htpasswd with provided file-locations
-    file { "${::nginx::config::conf_dir}/${location_sanitized}_htpasswd":
-      ensure => $ensure_real,
-      mode   => '0644',
-      source => $auth_basic_user_file,
-    }
-  }
 }

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -665,24 +665,6 @@ describe 'nginx::resource::location' do
         it { is_expected.not_to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-800-rspec-test-ssl")) }
       end
 
-      context 'when auth_basic_user_file => true' do
-        let :params do { :auth_basic_user_file => '/path/to/file', :vhost => 'vhost1', :www_root => '/', } end
-
-        it { is_expected.to contain_file("/etc/nginx/rspec-test_htpasswd") }
-      end
-
-      context 'when ensure => absent' do
-        let :params do {
-          :www_root             => '/',
-          :vhost                => 'vhost1',
-          :ensure               => 'absent',
-          :ssl                  => true,
-          :auth_basic_user_file => '/path/to/file',
-        } end
-
-        it { is_expected.to contain_file("/etc/nginx/rspec-test_htpasswd").with_ensure('absent') }
-      end
-
       context "vhost missing" do
         let :params do {
           :www_root => '/',


### PR DESCRIPTION
All it's doing right now is copying a file, but the copy of the file is never referenced by the template.

Fixes #572 