### PR TITLE
package/debian: support puppetlabs-apt 2.0.0

### DIFF
--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -37,7 +37,6 @@ class nginx::package::debian(
           location   => "http://nginx.org/packages/${distro}",
           repos      => 'nginx',
           key        => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62',
-          key_source => 'http://nginx.org/keys/nginx_signing.key',
         }
       }
       'nginx-mainline': {
@@ -45,7 +44,6 @@ class nginx::package::debian(
           location   => "http://nginx.org/packages/mainline/${distro}",
           repos      => 'nginx',
           key        => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62',
-          key_source => 'http://nginx.org/keys/nginx_signing.key',
         }
       }
       'passenger': {
@@ -53,8 +51,11 @@ class nginx::package::debian(
           location          => 'https://oss-binaries.phusionpassenger.com/apt/passenger',
           repos             => 'main',
           key               => '16378A33A6EF16762922526E561F9B9CAC40B2F7',
-          key_source        => 'https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key.txt',
-          required_packages => 'apt-transport-https ca-certificates',
+        }
+
+        package { ['apt-transport-https', 'ca-certificates']:
+          ensure => 'present',
+          before => Apt::Source['nginx'],
         }
 
         package { 'passenger':

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/jfryman/puppet-nginx/issues",
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.2.0 <5.0.0"},
-    {"name":"puppetlabs/apt","version_requirement":">= 1.0.0 <3.0.0"},
+    {"name":"puppetlabs/apt","version_requirement":">= 1.8.0 <3.0.0"},
     {"name":"puppetlabs/concat","version_requirement":">= 1.1.1 <2.0.0"}
   ],
   "requirements": [

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/jfryman/puppet-nginx/issues",
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.2.0 <5.0.0"},
-    {"name":"puppetlabs/apt","version_requirement":">= 1.0.0 <2.0.0"},
+    {"name":"puppetlabs/apt","version_requirement":">= 1.0.0 <3.0.0"},
     {"name":"puppetlabs/concat","version_requirement":">= 1.1.1 <2.0.0"}
   ],
   "requirements": [

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -68,7 +68,6 @@ describe 'nginx::package' do
         'location'   => "http://nginx.org/packages/#{operatingsystem.downcase}",
         'repos'      => 'nginx',
         'key'        => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62',
-        'key_source' => 'http://nginx.org/keys/nginx_signing.key'
       )}
       it { is_expected.to contain_anchor('nginx::package::begin').that_comes_before('Class[nginx::package::debian]') }
       it { is_expected.to contain_anchor('nginx::package::end').that_requires('Class[nginx::package::debian]') }
@@ -89,7 +88,6 @@ describe 'nginx::package' do
         'location'   => 'https://oss-binaries.phusionpassenger.com/apt/passenger',
         'repos'      => "main",
         'key'        => '16378A33A6EF16762922526E561F9B9CAC40B2F7',
-        'key_source' => 'https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key.txt'
       )}
     end
 


### PR DESCRIPTION
puppetlabs-apt 2.0.0 drops support in apt::source for key_source and required_packages.

* key_source will default to keyserver.ubuntu.com which carries both keys, so it
  doesn't need to be explicitly defined
* required_packages can be emulated with the package resource

Fixes #611 