### PR TITLE
Add passenger_set_header and passenger_env_var parameters for Passenger 5.0+

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -127,7 +127,7 @@
 #     options like error level to the end.
 #   [*passenger_cgi_param*]     - Allows one to define additional CGI environment
 #     variables to pass to the backend application
-#   [*passenger_header*]        - Allows one to set headers to pass to the
+#   [*passenger_set_header*]        - Allows one to set headers to pass to the
 #     backend application (Passenger 5.0+)
 #   [*passenger_env_var*]       - Allows one to set environemnt variables to pass
 #     to the backend application (Passenger 5.0+)
@@ -231,7 +231,7 @@ define nginx::resource::vhost (
   $error_log                    = undef,
   $format_log                   = 'combined',
   $passenger_cgi_param          = undef,
-  $passenger_header             = undef,
+  $passenger_set_header         = undef,
   $passenger_env_var            = undef,
   $log_by_lua                   = undef,
   $log_by_lua_file              = undef,
@@ -414,8 +414,8 @@ define nginx::resource::vhost (
   if ($passenger_cgi_param != undef) {
     validate_hash($passenger_cgi_param)
   }
-  if ($passenger_header != undef) {
-    validate_hash($passenger_header)
+  if ($passenger_set_header != undef) {
+    validate_hash($passenger_set_header)
   }
   if ($passenger_env_var != undef) {
     validate_hash($passenger_env_var)

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -127,6 +127,8 @@
 #     options like error level to the end.
 #   [*passenger_cgi_param*]     - Allows one to define additional CGI environment
 #     variables to pass to the backend application
+#   [*passenger_header*]        - Allows one to set headers to pass to the
+#     backend application (Passenger 5.0+)
 #   [*log_by_lua*]              - Run the Lua source code inlined as the
 #     <lua-script-str> at the log request processing phase.
 #     This does not replace the current access logs, but runs after.
@@ -227,6 +229,7 @@ define nginx::resource::vhost (
   $error_log                    = undef,
   $format_log                   = 'combined',
   $passenger_cgi_param          = undef,
+  $passenger_header             = undef,
   $log_by_lua                   = undef,
   $log_by_lua_file              = undef,
   $use_default_location         = true,
@@ -407,6 +410,9 @@ define nginx::resource::vhost (
   }
   if ($passenger_cgi_param != undef) {
     validate_hash($passenger_cgi_param)
+  }
+  if ($passenger_header != undef) {
+    validate_hash($passenger_header)
   }
   if ($log_by_lua != undef) {
     validate_string($log_by_lua)

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -129,6 +129,8 @@
 #     variables to pass to the backend application
 #   [*passenger_header*]        - Allows one to set headers to pass to the
 #     backend application (Passenger 5.0+)
+#   [*passenger_env_var*]       - Allows one to set environemnt variables to pass
+#     to the backend application (Passenger 5.0+)
 #   [*log_by_lua*]              - Run the Lua source code inlined as the
 #     <lua-script-str> at the log request processing phase.
 #     This does not replace the current access logs, but runs after.
@@ -230,6 +232,7 @@ define nginx::resource::vhost (
   $format_log                   = 'combined',
   $passenger_cgi_param          = undef,
   $passenger_header             = undef,
+  $passenger_env_var            = undef,
   $log_by_lua                   = undef,
   $log_by_lua_file              = undef,
   $use_default_location         = true,
@@ -413,6 +416,9 @@ define nginx::resource::vhost (
   }
   if ($passenger_header != undef) {
     validate_hash($passenger_header)
+  }
+  if ($passenger_env_var != undef) {
+    validate_hash($passenger_env_var)
   }
   if ($log_by_lua != undef) {
     validate_string($log_by_lua)

--- a/spec/defines/resource_vhost_spec.rb
+++ b/spec/defines/resource_vhost_spec.rb
@@ -876,6 +876,29 @@ describe 'nginx::resource::vhost' do
         it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content( /passenger_set_header  test3 test value 3;/ ) }
       end
 
+      context 'when passenger_env_var is set' do
+        let :params do default_params.merge({
+          :passenger_env_var => { 'test1' => 'test value 1', 'test2' => 'test value 2', 'test3' => 'test value 3' }
+        }) end
+
+        it { is_expected.to contain_concat__fragment("#{title}-header").with_content( /passenger_set_env_var  test1 test value 1;/ ) }
+        it { is_expected.to contain_concat__fragment("#{title}-header").with_content( /passenger_set_env_var  test2 test value 2;/ ) }
+        it { is_expected.to contain_concat__fragment("#{title}-header").with_content( /passenger_set_env_var  test3 test value 3;/ ) }
+      end
+
+      context 'when passenger_env_var is set and ssl => true' do
+        let :params do default_params.merge({
+          :passenger_env_var   => { 'test1' => 'test value 1', 'test2' => 'test value 2', 'test3' => 'test value 3' },
+          :ssl                 => true,
+          :ssl_key             => 'dummy.key',
+          :ssl_cert            => 'dummy.cert',
+        }) end
+
+        it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content( /passenger_set_env_var  test1 test value 1;/ ) }
+        it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content( /passenger_set_env_var  test2 test value 2;/ ) }
+        it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content( /passenger_set_env_var  test3 test value 3;/ ) }
+      end
+
       context 'when vhost name is sanitized' do
         let :title do 'www rspec-vhost com' end
         let :params do default_params end

--- a/spec/defines/resource_vhost_spec.rb
+++ b/spec/defines/resource_vhost_spec.rb
@@ -853,6 +853,29 @@ describe 'nginx::resource::vhost' do
         it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content( /passenger_set_cgi_param  test3 test value 3;/ ) }
       end
 
+      context 'when passenger_header is set' do
+        let :params do default_params.merge({
+          :passenger_header => { 'test1' => 'test value 1', 'test2' => 'test value 2', 'test3' => 'test value 3' }
+        }) end
+
+        it { is_expected.to contain_concat__fragment("#{title}-header").with_content( /passenger_set_header  test1 test value 1;/ ) }
+        it { is_expected.to contain_concat__fragment("#{title}-header").with_content( /passenger_set_header  test2 test value 2;/ ) }
+        it { is_expected.to contain_concat__fragment("#{title}-header").with_content( /passenger_set_header  test3 test value 3;/ ) }
+      end
+
+      context 'when passenger_header is set and ssl => true' do
+        let :params do default_params.merge({
+          :passenger_header    => { 'test1' => 'test value 1', 'test2' => 'test value 2', 'test3' => 'test value 3' },
+          :ssl                 => true,
+          :ssl_key             => 'dummy.key',
+          :ssl_cert            => 'dummy.cert',
+        }) end
+
+        it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content( /passenger_set_header  test1 test value 1;/ ) }
+        it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content( /passenger_set_header  test2 test value 2;/ ) }
+        it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content( /passenger_set_header  test3 test value 3;/ ) }
+      end
+
       context 'when vhost name is sanitized' do
         let :title do 'www rspec-vhost com' end
         let :params do default_params end

--- a/spec/defines/resource_vhost_spec.rb
+++ b/spec/defines/resource_vhost_spec.rb
@@ -853,9 +853,9 @@ describe 'nginx::resource::vhost' do
         it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content( /passenger_set_cgi_param  test3 test value 3;/ ) }
       end
 
-      context 'when passenger_header is set' do
+      context 'when passenger_set_header is set' do
         let :params do default_params.merge({
-          :passenger_header => { 'test1' => 'test value 1', 'test2' => 'test value 2', 'test3' => 'test value 3' }
+          :passenger_set_header => { 'test1' => 'test value 1', 'test2' => 'test value 2', 'test3' => 'test value 3' }
         }) end
 
         it { is_expected.to contain_concat__fragment("#{title}-header").with_content( /passenger_set_header  test1 test value 1;/ ) }
@@ -863,12 +863,12 @@ describe 'nginx::resource::vhost' do
         it { is_expected.to contain_concat__fragment("#{title}-header").with_content( /passenger_set_header  test3 test value 3;/ ) }
       end
 
-      context 'when passenger_header is set and ssl => true' do
+      context 'when passenger_set_header is set and ssl => true' do
         let :params do default_params.merge({
-          :passenger_header    => { 'test1' => 'test value 1', 'test2' => 'test value 2', 'test3' => 'test value 3' },
-          :ssl                 => true,
-          :ssl_key             => 'dummy.key',
-          :ssl_cert            => 'dummy.cert',
+          :passenger_set_header => { 'test1' => 'test value 1', 'test2' => 'test value 2', 'test3' => 'test value 3' },
+          :ssl                  => true,
+          :ssl_key              => 'dummy.key',
+          :ssl_cert             => 'dummy.cert',
         }) end
 
         it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content( /passenger_set_header  test1 test value 1;/ ) }
@@ -881,9 +881,9 @@ describe 'nginx::resource::vhost' do
           :passenger_env_var => { 'test1' => 'test value 1', 'test2' => 'test value 2', 'test3' => 'test value 3' }
         }) end
 
-        it { is_expected.to contain_concat__fragment("#{title}-header").with_content( /passenger_set_env_var  test1 test value 1;/ ) }
-        it { is_expected.to contain_concat__fragment("#{title}-header").with_content( /passenger_set_env_var  test2 test value 2;/ ) }
-        it { is_expected.to contain_concat__fragment("#{title}-header").with_content( /passenger_set_env_var  test3 test value 3;/ ) }
+        it { is_expected.to contain_concat__fragment("#{title}-header").with_content( /passenger_env_var  test1 test value 1;/ ) }
+        it { is_expected.to contain_concat__fragment("#{title}-header").with_content( /passenger_env_var  test2 test value 2;/ ) }
+        it { is_expected.to contain_concat__fragment("#{title}-header").with_content( /passenger_env_var  test3 test value 3;/ ) }
       end
 
       context 'when passenger_env_var is set and ssl => true' do
@@ -894,9 +894,9 @@ describe 'nginx::resource::vhost' do
           :ssl_cert            => 'dummy.cert',
         }) end
 
-        it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content( /passenger_set_env_var  test1 test value 1;/ ) }
-        it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content( /passenger_set_env_var  test2 test value 2;/ ) }
-        it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content( /passenger_set_env_var  test3 test value 3;/ ) }
+        it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content( /passenger_env_var  test1 test value 1;/ ) }
+        it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content( /passenger_env_var  test2 test value 2;/ ) }
+        it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content( /passenger_env_var  test3 test value 3;/ ) }
       end
 
       context 'when vhost name is sanitized' do

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -94,6 +94,11 @@ server {
   passenger_set_cgi_param  <%= key %> <%= @passenger_cgi_param[key] %>;
   <%- end -%>
 <% end -%>
+<% if @passenger_header -%>
+  <%- @passenger_header.keys.sort.each do |key| -%>
+  passenger_set_header  <%= key %> <%= @passenger_header[key] %>;
+  <%- end -%>
+<% end -%>
 <% if Array(@resolver).count > 0 -%>
   resolver                  <% Array(@resolver).each do |r| %> <%= r %><% end %>;
 <% end -%>

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -99,6 +99,11 @@ server {
   passenger_set_header  <%= key %> <%= @passenger_header[key] %>;
   <%- end -%>
 <% end -%>
+<% if @passenger_env_var -%>
+  <%- @passenger_env_var.keys.sort.each do |key| -%>
+  passenger_set_env_var  <%= key %> <%= @passenger_env_var[key] %>;
+  <%- end -%>
+<% end -%>
 <% if Array(@resolver).count > 0 -%>
   resolver                  <% Array(@resolver).each do |r| %> <%= r %><% end %>;
 <% end -%>

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -94,14 +94,14 @@ server {
   passenger_set_cgi_param  <%= key %> <%= @passenger_cgi_param[key] %>;
   <%- end -%>
 <% end -%>
-<% if @passenger_header -%>
-  <%- @passenger_header.keys.sort.each do |key| -%>
-  passenger_set_header  <%= key %> <%= @passenger_header[key] %>;
+<% if @passenger_set_header -%>
+  <%- @passenger_set_header.keys.sort.each do |key| -%>
+  passenger_set_header  <%= key %> <%= @passenger_set_header[key] %>;
   <%- end -%>
 <% end -%>
 <% if @passenger_env_var -%>
   <%- @passenger_env_var.keys.sort.each do |key| -%>
-  passenger_set_env_var  <%= key %> <%= @passenger_env_var[key] %>;
+  passenger_env_var  <%= key %> <%= @passenger_env_var[key] %>;
   <%- end -%>
 <% end -%>
 <% if Array(@resolver).count > 0 -%>

--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -152,11 +152,11 @@ server {
 <% Array(@passenger_cgi_param).each do |key,value| -%>
   passenger_set_cgi_param  <%= key %> <%= value %>;
 <% end -%>
-<% Array(@passenger_header).each do |key,value| -%>
+<% Array(@passenger_set_header).each do |key,value| -%>
   passenger_set_header  <%= key %> <%= value %>;
 <% end -%>
 <% Array(@passenger_env_var).each do |key,value| -%>
-  passenger_set_env_var  <%= key %> <%= value %>;
+  passenger_env_var  <%= key %> <%= value %>;
 <% end -%>
 <% Array(@add_header).each do |key,value| -%>
   add_header              <%= key %> <%= value %>;

--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -155,6 +155,9 @@ server {
 <% Array(@passenger_header).each do |key,value| -%>
   passenger_set_header  <%= key %> <%= value %>;
 <% end -%>
+<% Array(@passenger_env_var).each do |key,value| -%>
+  passenger_set_env_var  <%= key %> <%= value %>;
+<% end -%>
 <% Array(@add_header).each do |key,value| -%>
   add_header              <%= key %> <%= value %>;
 <% end -%>

--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -152,6 +152,9 @@ server {
 <% Array(@passenger_cgi_param).each do |key,value| -%>
   passenger_set_cgi_param  <%= key %> <%= value %>;
 <% end -%>
+<% Array(@passenger_header).each do |key,value| -%>
+  passenger_set_header  <%= key %> <%= value %>;
+<% end -%>
 <% Array(@add_header).each do |key,value| -%>
   add_header              <%= key %> <%= value %>;
 <% end -%>


### PR DESCRIPTION
Passenger 5.0 deprecates passenger_set_cgi_param and replaced it with passenger_set_header and passenger_env_var. This allows you to specify those parameters.

https://blog.phusion.nl/2015/03/04/phusion-passenger-5-0-1-released/