### PR TITLE
fix rewrite_www_to_non_www vhost

### DIFF
--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -2,19 +2,19 @@
 server {
   <%- if @listen_ip.is_a?(Array) then -%>
     <%- @listen_ip.each do |ip| -%>
-  listen       <%= ip %>:<%= @listen_port %><% if @listen_options %> <%= @listen_options %><% end %>;
+  listen       <%= ip %>:<%= @listen_port %>;
     <%- end -%>
   <%- else -%>
-  listen       <%= @listen_ip %>:<%= @listen_port %><% if @listen_options %> <%= @listen_options %><% end %>;
+  listen       <%= @listen_ip %>:<%= @listen_port %>;
   <%- end -%>
 <%# check to see if ipv6 support exists in the kernel before applying -%>
   <%- if @ipv6_enable && (defined? @ipaddress6) -%>
     <%- if @ipv6_listen_ip.is_a?(Array) then -%>
       <%- @ipv6_listen_ip.each do |ipv6| -%>
-  listen [<%= ipv6 %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
+  listen [<%= ipv6 %>]:<%= @ipv6_listen_port %>;
       <%- end -%>
     <%- else -%>
-  listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
+  listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %>;
     <%- end -%>
   <%- end -%>
   server_name  www.<%= @server_name[0].gsub(/^www\./, '') %>;

--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -2,19 +2,19 @@
 server {
   <%- if @listen_ip.is_a?(Array) then -%>
     <%- @listen_ip.each do |ip| -%>
-  listen       <%= ip %>:<%= @ssl_port %> <% if @ssl_listen_option %>ssl<% end %><% if @spdy == 'on' %> spdy<% end %><% if @listen_options %> <%= @listen_options %><% end %>;
+  listen       <%= ip %>:<%= @ssl_port %>;
     <%- end -%>
   <%- else -%>
-  listen       <%= @listen_ip %>:<%= @ssl_port %> <% if @ssl_listen_option %>ssl<% end %><% if @spdy == 'on' %> spdy<% end %><% if @listen_options %> <%= @listen_options %><% end %>;
+  listen       <%= @listen_ip %>:<%= @ssl_port %>;
   <%- end -%>
 <%# check to see if ipv6 support exists in the kernel before applying -%>
   <%- if @ipv6_enable && (defined? @ipaddress6) -%>
     <%- if @ipv6_listen_ip.is_a?(Array) then -%>
       <%- @ipv6_listen_ip.each do |ipv6| -%>
-  listen [<%= ipv6 %>]:<%= @ssl_port %> ssl<% if @spdy == 'on' %> spdy<% end %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
+  listen [<%= ipv6 %>]:<%= @ssl_port %>;
       <%- end -%>
     <%- else -%>
-  listen       [<%= @ipv6_listen_ip %>]:<%= @ssl_port %> ssl<% if @spdy == 'on' %> spdy<% end %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
+  listen       [<%= @ipv6_listen_ip %>]:<%= @ssl_port %>;
     <%- end -%>
   <%- end -%>
   server_name  www.<%= @server_name[0].gsub(/^www\./, '') %>;


### PR DESCRIPTION
The www-to-non-www vhost actually does not need any further listen_options (e.g., see [here](http://serverfault.com/a/548942)).