### PR TITLE
Require base folder for resources

### DIFF
--- a/manifests/resource/upstream.pp
+++ b/manifests/resource/upstream.pp
@@ -70,6 +70,7 @@ define nginx::resource::upstream (
   concat { "${::nginx::config::conf_dir}/conf.d/${name}-upstream.conf":
     ensure => $ensure_real,
     notify => Class['::nginx::service'],
+    require => File["${::nginx::config::conf_dir}/conf.d/"]
   }
 
   # Uses: $name, $upstream_cfg_prepend

--- a/manifests/resource/upstream.pp
+++ b/manifests/resource/upstream.pp
@@ -68,9 +68,9 @@ define nginx::resource::upstream (
   }
 
   concat { "${::nginx::config::conf_dir}/conf.d/${name}-upstream.conf":
-    ensure => $ensure_real,
-    notify => Class['::nginx::service'],
-    require => File["${::nginx::config::conf_dir}/conf.d/"]
+    ensure  => $ensure_real,
+    notify  => Class['::nginx::service'],
+    require => File["${::nginx::config::conf_dir}/conf.d"]
   }
 
   # Uses: $name, $upstream_cfg_prepend

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -495,10 +495,11 @@ define nginx::resource::vhost (
   }
 
   concat { $config_file:
-    owner  => $owner,
-    group  => $group,
-    mode   => $mode,
-    notify => Class['::nginx::service'],
+    owner   => $owner,
+    group   => $group,
+    mode    => $mode,
+    notify  => Class['::nginx::service'],
+    require => File[$vhost_dir]
   }
 
   $ssl_only = ($ssl == true) and ($ssl_port == $listen_port)


### PR DESCRIPTION
Hello James

Not sure if this issue is related to the changes in the concat module, but since it was updated we start having errors like:

==> single: Error: Could not set 'file' on ensure: No such file or directory - /etc/nginx/conf.d/drupal-upstream.conf20150506-4095-ep3q6b.lock
==> single: Error: Could not set 'file' on ensure: No such file or directory - /etc/nginx/conf.d/drupal-upstream.conf20150506-4095-ep3q6b.lock
==> single: Wrapped exception:
==> single: No such file or directory - /etc/nginx/conf.d/drupal-upstream.conf20150506-4095-ep3q6b.lock
==> single: Error: /Stage[main]/Dotdrupal/Dotdrupal::Site[drupal]/Dotdrupal::Nginx[nginx for drupal]/Nginx::Resource::Upstream[drupal]/Concat[/etc/nginx/conf.d/drupal-upstream.conf]/File[/etc/nginx/conf.d/drupal-upstream.conf]/ensure: change from absent to file failed: Could not set 'file' on ensure: No such file or directory - /etc/nginx/conf.d/drupal-upstream.conf20150506-4095-ep3q6b.lock

We weren't having this before :( i've dig into NGINX manifest and find a way to solve them by just requiring the destination folder in the concat resources.

Hope it can be merged

Regards

M 