### PR TITLE
remove ensure from concat::fragment as its deprecated

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -348,7 +348,6 @@ define nginx::resource::location (
     $tmpFile=md5("${vhost_sanitized}-${priority}-${location_sanitized}")
 
     concat::fragment { $tmpFile:
-      ensure  => $ensure,
       target  => $config_file,
       content => join([
         template('nginx/vhost/location_header.erb'),
@@ -365,7 +364,6 @@ define nginx::resource::location (
 
     $sslTmpFile=md5("${vhost_sanitized}-${ssl_priority}-${location_sanitized}-ssl")
     concat::fragment { $sslTmpFile:
-      ensure  => $ensure,
       target  => $config_file,
       content => join([
         template('nginx/vhost/location_header.erb'),

--- a/manifests/resource/mailhost.pp
+++ b/manifests/resource/mailhost.pp
@@ -133,7 +133,6 @@ define nginx::resource::mailhost (
 
   if ($listen_port != $ssl_port) {
     concat::fragment { "${name}-header":
-      ensure  => present,
       target  => $config_file,
       content => template('nginx/mailhost/mailhost.erb'),
       order   => '001',
@@ -143,7 +142,6 @@ define nginx::resource::mailhost (
   # Create SSL File Stubs if SSL is enabled
   if ($ssl) {
     concat::fragment { "${name}-ssl":
-      ensure  => present,
       target  => $config_file,
       content => template('nginx/mailhost/mailhost_ssl.erb'),
       order   => '700',

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -571,7 +571,6 @@ define nginx::resource::vhost (
 
   if ($listen_port != $ssl_port) {
     concat::fragment { "${name_sanitized}-header":
-      ensure  => present,
       target  => $config_file,
       content => template('nginx/vhost/vhost_header.erb'),
       order   => '001',
@@ -581,7 +580,6 @@ define nginx::resource::vhost (
   # Create a proper file close stub.
   if ($listen_port != $ssl_port) {
     concat::fragment { "${name_sanitized}-footer":
-      ensure  => present,
       target  => $config_file,
       content => template('nginx/vhost/vhost_footer.erb'),
       order   => '699',


### PR DESCRIPTION
In the last puppetlabs-concat version the ensure parameter was deprecated inside the concat::fragment

I've removed all the matches i've found and run the tests successfully.

Hope it can be merged.

Regards

M