### PR TITLE
Fail on lint warnings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ require 'puppet_blacksmith/rake_tasks'
 
 task :default => [:clean, :spec]
 
-PuppetLint.configuration.fail_on_warnings
+PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.send('relative')
 PuppetLint.configuration.send('disable_80chars')
 PuppetLint.configuration.send('disable_class_inherits_from_params_class')

--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -34,23 +34,23 @@ class nginx::package::debian(
     case $package_source {
       'nginx', 'nginx-stable': {
         apt::source { 'nginx':
-          location   => "http://nginx.org/packages/${distro}",
-          repos      => 'nginx',
-          key        => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62',
+          location => "http://nginx.org/packages/${distro}",
+          repos    => 'nginx',
+          key      => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62',
         }
       }
       'nginx-mainline': {
         apt::source { 'nginx':
-          location   => "http://nginx.org/packages/mainline/${distro}",
-          repos      => 'nginx',
-          key        => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62',
+          location => "http://nginx.org/packages/mainline/${distro}",
+          repos    => 'nginx',
+          key      => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62',
         }
       }
       'passenger': {
         apt::source { 'nginx':
-          location          => 'https://oss-binaries.phusionpassenger.com/apt/passenger',
-          repos             => 'main',
-          key               => '16378A33A6EF16762922526E561F9B9CAC40B2F7',
+          location => 'https://oss-binaries.phusionpassenger.com/apt/passenger',
+          repos    => 'main',
+          key      => '16378A33A6EF16762922526E561F9B9CAC40B2F7',
         }
 
         package { ['apt-transport-https', 'ca-certificates']:


### PR DESCRIPTION
The lint rake task had stopped failing on warnings for some reason... this PR re-enables it.