### PR TITLE
travis: drop ruby 1.8.7 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ bundler_args: --without rake
 matrix:
   fast_finish: true
   include:
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 2.7.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 3.0"
     - rvm: 1.9.3
       env: PUPPET_GEM_VERSION="~> 3.0"
     - rvm: 2.0.0
@@ -22,10 +18,5 @@ matrix:
       env: PUPPET_GEM_VERSION="~> 3.0"
     - rvm: 2.1.0
       env: PUPPET_GEM_VERSION="~> 4.0"
-  allow_failures:
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 2.7.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 3.0"
 notifications:
-  email: false  
+  email: false


### PR DESCRIPTION
The Ruby 1.8.7 tests have been broken for ages, and it's unlikely anyone will do the work to restore support for the tests. Drop them from the suite to save Travis CI from doing work for nothing on every commit.