### PR TITLE
Create directory for log files

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -209,6 +209,10 @@ class nginx::config(
     ensure => directory,
   }
 
+  file { $log_dir:
+    ensure => directory,
+  }
+
   file {$client_body_temp_path:
     ensure => directory,
     owner  => $daemon_user,

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -68,6 +68,12 @@ describe 'nginx::config' do
         it { is_expected.to contain_file("/var/nginx/proxy_temp").with(:owner => 'nginx')}
         it { is_expected.to contain_file("/etc/nginx/nginx.conf").with_content %r{^user nginx;}}
 
+        it { is_expected.to contain_file("/var/log/nginx").with(
+          :ensure => 'directory',
+          :group => 'root',
+          :mode => '0644'
+        )}
+
     describe "nginx.conf template content" do
       [
         {
@@ -510,6 +516,11 @@ describe 'nginx::config' do
         'recurse'
       ])}
       it { is_expected.to contain_file('/etc/nginx/sites-enabled').without([
+        'ignore',
+        'purge',
+        'recurse'
+      ])}
+      it { is_expected.to contain_file('/var/log/nginx').without([
         'ignore',
         'purge',
         'recurse'


### PR DESCRIPTION
I've added loose management and creation of the nginx access log and error log files. If they don't exist then nginx will not pass its config test and won't start up (on FreeBSD at least), so these files need to exist prior to nginx being started or reloaded.

I've included specs which are passing, and I think testing the right things I'm not very familiar with testing puppet yet. Testing my branch on a virtual machine results in a successfully started nginx service too.

I also think I've managed to stick to the style guidelines, I've run the `rake lint`, `rake syntax` and `rake validate` tasks and I think they've all passed as well.

I'm not sure if this is the right thing to do or not though

``` puppet
if $vhost_purge == true {
   File[$log_dir] {
     purge   => true,
     recurse => true,
   }
}
```

Fixes #619 