### PR TITLE
Revert "Require base folder for resources"

### DIFF
--- a/manifests/resource/upstream.pp
+++ b/manifests/resource/upstream.pp
@@ -68,9 +68,8 @@ define nginx::resource::upstream (
   }
 
   concat { "${::nginx::config::conf_dir}/conf.d/${name}-upstream.conf":
-    ensure  => $ensure_real,
-    notify  => Class['::nginx::service'],
-    require => File["${::nginx::config::conf_dir}/conf.d"]
+    ensure => $ensure_real,
+    notify => Class['::nginx::service'],
   }
 
   # Uses: $name, $upstream_cfg_prepend

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -518,11 +518,10 @@ define nginx::resource::vhost (
   }
 
   concat { $config_file:
-    owner   => $owner,
-    group   => $group,
-    mode    => $mode,
-    notify  => Class['::nginx::service'],
-    require => File[$vhost_dir]
+    owner  => $owner,
+    group  => $group,
+    mode   => $mode,
+    notify => Class['::nginx::service'],
   }
 
   $ssl_only = ($ssl == true) and ($ssl_port == $listen_port)


### PR DESCRIPTION
Reverts #624

The puppetlabs-concat 2.x series has been yanked from release. These changes are no longer necessary.

More at https://groups.google.com/forum/#!topic/puppet-users/4_Sxrfl4uUY