### PR TITLE
Don't qualified call to defined resource type

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -530,7 +530,7 @@ define nginx::resource::vhost (
 
   if $use_default_location == true {
     # Create the default location reference for the vHost
-    ::nginx::resource::location {"${name_sanitized}-default":
+    nginx::resource::location {"${name_sanitized}-default":
       ensure                      => $ensure,
       vhost                       => $name_sanitized,
       ssl                         => $ssl,


### PR DESCRIPTION
I don't think this is such an improvement (over non qualification).

My main motivation comes from the fact that it is not currently supported so well by "language-puppet".