### PR TITLE
Update non-hiera usage (see #536)

### DIFF
--- a/docs/hiera.md
+++ b/docs/hiera.md
@@ -30,19 +30,29 @@ Maybe for some reason, Hiera isn't being used in your organization. Or, you like
 Assume the same code block as before:
 
 ```ruby
-class { 'nginx':
-  gzip => false,
+class { 'nginx' :
+  manage_repo   => false,
+  confd_purge   => true,
+  vhost_purge   => true,
 }
 ```
 
 Should become...
 
 ```ruby
-include nginx
-class { 'nginx::config':
-  gzip => false,
+Anchor['nginx::begin']
+->
+class { 'nginx::config' :
+  confd_purge   => true,
+  vhost_purge   => true,
+}
+
+class { 'nginx' :
+  manage_repo   => false,
 }
 ```
+
+The order in which this commands are parsed is important, since nginx looks for nginx::config via a defined(nginx::config) statement, which as of puppet 3.x is still parse-order dependent.
 
 # Why again are you doing this?
 

--- a/docs/hiera.md
+++ b/docs/hiera.md
@@ -27,7 +27,7 @@ Magically, it's all done! Work through these until the deprecation notices go aw
 
 Maybe for some reason, Hiera isn't being used in your organization. Or, you like to keep a certain amount of composibilty in you modules. Or, hidden option #3! Regardless, the recommended path is to instantiate your own copy of Class[nginx::config] and move on with life. Let's do another example.
 
-Assume the same code block as before:
+Assume you have the following code block:
 
 ```ruby
 class { 'nginx' :
@@ -37,7 +37,7 @@ class { 'nginx' :
 }
 ```
 
-Should become...
+This should become...
 
 ```ruby
 Anchor['nginx::begin']


### PR DESCRIPTION
As described in issue #536, the example on how to use nginx correctly without hiera needs to be updated to fix parse-order dependency with defined(nginx::config) with puppet 3.x. 