### PR TITLE
Add 'ensure' parameter to resource::upstream::member.

### DIFF
--- a/manifests/resource/upstream/member.pp
+++ b/manifests/resource/upstream/member.pp
@@ -9,6 +9,7 @@
 #
 #
 # Parameters:
+#   [*ensure*]                  - Enables or disables the specified member (present|absent)
 #   [*upstream*]                - The name of the upstream resource
 #   [*server*]                  - Hostname or IP of the upstream member server
 #   [*port*]                    - Port of the listening service on the upstream member
@@ -20,6 +21,7 @@
 #   Exporting the resource on a upstream member server:
 #
 #   @@nginx::resource::upstream::member { $::fqdn:
+#     ensure    => present,
 #     upstream  => 'proxypass',
 #     server    => $::ipaddress,
 #     port      => '3000',
@@ -35,12 +37,22 @@
 define nginx::resource::upstream::member (
   $upstream,
   $server,
+  $ensure                 = 'present',
   $port                   = '80',
   $upstream_fail_timeout  = '10s',
 ) {
 
+  validate_re($ensure, '^(present|absent)$',
+    "${ensure} is not supported for ensure. Allowed values are 'present' and 'absent'.")
+
+  $ensure_real = $ensure ? {
+    'absent' => absent,
+    default  => present,
+  }
+
   # Uses: $server, $port, $upstream_fail_timeout
   concat::fragment { "${upstream}_upstream_member_${name}":
+    ensure  => $ensure_real,
     target  => "${::nginx::config::conf_dir}/conf.d/${upstream}-upstream.conf",
     order   => 40,
     content => template('nginx/conf.d/upstream_member.erb'),

--- a/templates/vhost/location_footer.erb
+++ b/templates/vhost/location_footer.erb
@@ -18,12 +18,12 @@
     <%- if value.is_a?(Hash) -%>
       <%- value.sort_by {|k,v| k}.each do |subkey,subvalue| -%>
         <%- Array(subvalue).each do |asubvalue| -%>
-    <%= key %> <%= subkey %> <%= asubvalue %>
+    <%= key %> <%= subkey %> <%= asubvalue %>;
         <%- end -%>
       <%- end -%>
     <%- else -%>
       <%- Array(value).each do |asubvalue| -%>
-    <%= key %> <%= asubvalue %>
+    <%= key %> <%= asubvalue %>;
       <%- end -%>
     <%- end -%>
   <%- end -%>

--- a/templates/vhost/location_footer.erb
+++ b/templates/vhost/location_footer.erb
@@ -18,12 +18,12 @@
     <%- if value.is_a?(Hash) -%>
       <%- value.sort_by {|k,v| k}.each do |subkey,subvalue| -%>
         <%- Array(subvalue).each do |asubvalue| -%>
-    <%= key %> <%= subkey %> <%= asubvalue %>;
+    <%= key %> <%= subkey %> <%= asubvalue %>
         <%- end -%>
       <%- end -%>
     <%- else -%>
       <%- Array(value).each do |asubvalue| -%>
-    <%= key %> <%= asubvalue %>;
+    <%= key %> <%= asubvalue %>
       <%- end -%>
     <%- end -%>
   <%- end -%>


### PR DESCRIPTION
I'm using stored configs to create upstream::member on servers that should belong to up upstream.  Removing them while developing the puppet manifests if something goes wrong is troublesome without the ability to ensure => absent.

All tests are passing under ruby 2.1.2, though I didn't add new ones.