### PR TITLE
adding a max_fails parameter to upstream member[s]

### DIFF
--- a/manifests/resource/upstream.pp
+++ b/manifests/resource/upstream.pp
@@ -8,6 +8,7 @@
 #   [*ensure*]                - Enables or disables the specified location (present|absent)
 #   [*upstream_cfg_prepend*]  - It expects a hash with custom directives to put before anything else inside upstream
 #   [*upstream_fail_timeout*] - Set the fail_timeout for the upstream. Default is 10 seconds - As that is what Nginx does normally.
+#   [*upstream_max_fails*]    - Set the max_fails for the upstream. Default is to use nginx default value which is 1.
 #
 # Actions:
 #
@@ -43,6 +44,7 @@ define nginx::resource::upstream (
   $ensure = 'present',
   $upstream_cfg_prepend = undef,
   $upstream_fail_timeout = '10s',
+  $upstream_max_fails = undef,
 ) {
 
   if $members != undef {

--- a/templates/conf.d/upstream_member.erb
+++ b/templates/conf.d/upstream_member.erb
@@ -1,1 +1,1 @@
-  server     <%= @server %>:<%= @port %>  fail_timeout=<%= @upstream_fail_timeout %>;
+  server     <%= @server %>:<%= @port %>  fail_timeout=<%= @upstream_fail_timeout %><% if @upstream_max_fails -%> max_fails=<%=@upstream_max_fails %><% end %>;

--- a/templates/conf.d/upstream_members.erb
+++ b/templates/conf.d/upstream_members.erb
@@ -1,2 +1,2 @@
   <% @members.each do |i| %>
-  server     <%= i %>  fail_timeout=<%= @upstream_fail_timeout %>;<% end %>
+  server     <%= i %>  fail_timeout=<%= @upstream_fail_timeout %><% if @upstream_max_fails -%> max_fails=<%=@upstream_max_fails %><% end %>;<% end %>


### PR DESCRIPTION
As defined in nginx upstream documentation: http://nginx.org/en/docs/http/ngx_http_upstream_module.html#upstream

I added this optional parameter because we folks have to deal with a finicky backend that randomly timeout on a single request  when under heavy load. When this happens, the upstream gets disabled for 10 seconds (fail_timeout) and for that period of time other upstreams receive the requests which doesn't play nice with our application. 

Increasing this parameter to max_fails=3 ensures that load is switched only when really necessary. 

```
  nginx::resource::upstream { $upstream_name:
    ensure               => present,
    members              => $upstream_servers,
    upstream_cfg_prepend => {
      'ip_hash'   => '',
      'keepalive' => '128',
    },
    upstream_max_fails   => 3,
  }
```

becomes s: 

```
upstream backend {

  ip_hash ;

  keepalive 65;

  server     server1.domain  fail_timeout=10s max_fails=3;
  server     server2.domain  fail_timeout=10s max_fails=3;
}
```

Let me know if I should change anything, thanks