### PR TITLE
iterate server_name when rewrite_www_to_non_www is used

### DIFF
--- a/spec/defines/resource_vhost_spec.rb
+++ b/spec/defines/resource_vhost_spec.rb
@@ -711,8 +711,8 @@ describe 'nginx::resource::vhost' do
           }
         end
 
-        it "should set the server_name of the rewrite server stanza to the first server_name with 'www.' stripped" do
-          is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(/^\s+server_name\s+foo.com;/)
+        it "should set the server_name of the rewrite server stanza to every server_name with 'www.' stripped" do
+          is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(/^\s+server_name\s+foo.com\s+bar.foo.com\s+foo.com;/)
         end
       end
 
@@ -726,8 +726,8 @@ describe 'nginx::resource::vhost' do
           }
         end
 
-        it "should set the server_name of the rewrite server stanza to the first server_name with 'www.' stripped" do
-          is_expected.to contain_concat__fragment("#{title}-header").with_content(/^\s+server_name\s+foo.com;/)
+        it "should set the server_name of the rewrite server stanza to every server_name with 'www.' stripped" do
+          is_expected.to contain_concat__fragment("#{title}-header").with_content(/^\s+server_name\s+foo.com\s+bar.foo.com\s+foo.com;/)
         end
       end
 

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -1,4 +1,5 @@
 <% if @rewrite_www_to_non_www -%>
+<%- @server_name.each do |s| -%>
 server {
   <%- if @listen_ip.is_a?(Array) then -%>
     <%- @listen_ip.each do |ip| -%>
@@ -17,10 +18,11 @@ server {
   listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
     <%- end -%>
   <%- end -%>
-  server_name  www.<%= @server_name[0].gsub(/^www\./, '') %>;
-  return       301 http://<%= @server_name[0].gsub(/^www\./, '') %>$request_uri;
+  server_name  www.<%= s.gsub(/^www\./, '') %>;
+  return       301 http://<%= s.gsub(/^www\./, '') %>$request_uri;
 }
 
+<% end -%>
 <% end -%>
 server {
 <%- if @listen_ip.is_a?(Array) then -%>
@@ -40,7 +42,7 @@ server {
   listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
   <%- end -%>
 <%- end -%>
-  server_name           <%= @rewrite_www_to_non_www ? @server_name[0].gsub(/^www\./, '') : @server_name.join(" ") %>;
+  server_name           <%= @rewrite_www_to_non_www ? @server_name.join("  ").gsub(/(^| )(www\.)?(?=[a-z0-9])/, '') : @server_name.join(" ") %>;
 <%- if instance_variables.any? { |iv| iv.to_s.include? 'auth_basic' } -%>
   <%- if defined? @auth_basic -%>
   auth_basic           "<%= @auth_basic %>";

--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -1,4 +1,5 @@
 <% if @rewrite_www_to_non_www -%>
+<%- @server_name.each do |s| -%>
 server {
   <%- if @listen_ip.is_a?(Array) then -%>
     <%- @listen_ip.each do |ip| -%>
@@ -17,13 +18,14 @@ server {
   listen       [<%= @ipv6_listen_ip %>]:<%= @ssl_port %> ssl<% if @spdy == 'on' %> spdy<% end %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
     <%- end -%>
   <%- end -%>
-  server_name  www.<%= @server_name[0].gsub(/^www\./, '') %>;
-  return       301 https://<%= @server_name[0].gsub(/^www\./, '') %>$request_uri;
+  server_name  www.<%= s.gsub(/^www\./, '') %>;
+  return       301 https://<%= s.gsub(/^www\./, '') %>$request_uri;
 
 <%= scope.function_template(["nginx/vhost/vhost_ssl_settings.erb"]) %>
 
 }
 
+<% end -%>
 <% end -%>
 server {
   <%- if @listen_ip.is_a?(Array) then -%>
@@ -43,7 +45,7 @@ server {
   listen       [<%= @ipv6_listen_ip %>]:<%= @ssl_port %> ssl<% if @spdy == 'on' %> spdy<% end %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
     <%- end -%>
   <%- end -%>
-  server_name  <%= @rewrite_www_to_non_www ? @server_name[0].gsub(/^www\./, '') : @server_name.join(" ") %>;
+  server_name  <%= @rewrite_www_to_non_www ? @server_name.join("  ").gsub(/(^| )(www\.)?(?=[a-z0-9])/, '') : @server_name.join(" ") %>;
 
 <%= scope.function_template(["nginx/vhost/vhost_ssl_settings.erb"]) %>
 


### PR DESCRIPTION
Was not working when server_name was an array

with
```
server_name            => [ 'a.example.com', 'b.example.org' ],
rewrite_www_to_non_www => true,
```

Before patch:
```
server {
  [...]
  server_name www.a.example.com;
  return 301 http://a.example.com$request_uri; 
}
[...]
server {
  [...]
  servername a.example.com
  [...]
}
```

now:
```
server {
  [...]
  server_name www.a.example.com;
  return 301 http://a.example.com$request_uri; 
}
server {
  [...]
  server_name www.b.example.org;
  return 301 http://b.example.org$request_uri; 
}

[...]
server {
  [...]
  servername a.example.com b.example.org
  [...]
}
```
```
