### PR TITLE
Ensure priority is an integer 

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -308,7 +308,7 @@ define nginx::resource::location (
     fail('$priority must be an integer.')
   }
   validate_array($rewrite_rules)
-  if ($priority < 401) or ($priority > 899) {
+  if (($priority + 0) < 401) or (($priority + 0) > 899) {
     fail('$priority must be in the range 401-899.')
   }
 

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -308,7 +308,7 @@ define nginx::resource::location (
     fail('$priority must be an integer.')
   }
   validate_array($rewrite_rules)
-  if (str2num($priority) < 401) or (str2num($priority) > 899) {
+  if (str2num("${priority}") < 401) or (str2num("${priority}") > 899) {
     fail('$priority must be in the range 401-899.')
   }
 

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -308,7 +308,7 @@ define nginx::resource::location (
     fail('$priority must be an integer.')
   }
   validate_array($rewrite_rules)
-  if (($priority + 0) < 401) or (($priority + 0) > 899) {
+  if (str2num($priority) < 401) or (str2num($priority) > 899) {
     fail('$priority must be in the range 401-899.')
   }
 

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -308,7 +308,7 @@ define nginx::resource::location (
     fail('$priority must be an integer.')
   }
   validate_array($rewrite_rules)
-  if (str2num("${priority}") < 401) or (str2num("${priority}") > 899) {
+  if (($priority + 0) < 401) or ((priority + 0) > 899) {
     fail('$priority must be in the range 401-899.')
   }
 


### PR DESCRIPTION
Ensure that priority is an integer before comparisonWith stringify_facts set to false puppet fails with this error: 

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Comparison of: String < Integer, is not possible. Caused by 'A String is not comparable to a non String'. at /srv/puppetmaster/current/modules/nginx/manifests/resource/location.pp:238:17 on node sa-sand-logyard1.sa.moneydesktop.com
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```

This ensures that $priority is an integer

https://docs.puppetlabs.com/puppet/latest/reference/lang_data_number.html#converting-strings-to-numbers