### PR TITLE
Convert $priority to integer before comparison

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -308,7 +308,7 @@ define nginx::resource::location (
     fail('$priority must be an integer.')
   }
   validate_array($rewrite_rules)
-  if ($priority < 401) or ($priority > 899) {
+  if (($priority + 0) < 401) or (($priority + 0) > 899) {
     fail('$priority must be in the range 401-899.')
   }
 


### PR DESCRIPTION
Comparison was causing an error with parser = future and stringify_facts = false. This ensures that the comparison is done between two integers

Fixes: #684 