### PR TITLE
Adding support for stream configuration

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -67,6 +67,7 @@ class nginx::config(
   $keepalive_timeout              = '65',
   $log_format                     = {},
   $mail                           = false,
+  $stream                         = false,
   $multi_accept                   = 'off',
   $names_hash_bucket_size         = '64',
   $names_hash_max_size            = '512',
@@ -182,6 +183,16 @@ class nginx::config(
 
   file { $conf_dir:
     ensure => directory,
+  }
+
+  file { "${conf_dir}/conf.stream.d":
+    ensure => directory,
+  }
+  if $confd_purge == true {
+    File["${conf_dir}/conf.stream.d"] {
+      purge   => true,
+      recurse => true,
+    }
   }
 
   file { "${conf_dir}/conf.d":

--- a/manifests/resource/streamhost.pp
+++ b/manifests/resource/streamhost.pp
@@ -1,0 +1,161 @@
+# define: nginx::resource::streamhost
+#
+# This definition creates a virtual host
+#
+# Parameters:
+#   [*ensure*]              - Enables or disables the specified streamhost
+#     (present|absent)
+#   [*listen_ip*]           - Default IP Address for NGINX to listen with this
+#     streamhost on. Defaults to all interfaces (*)
+#   [*listen_port*]         - Default IP Port for NGINX to listen with this
+#     streamhost on. Defaults to TCP 80
+#   [*listen_options*]      - Extra options for listen directive like
+#     'default' to catchall. Undef by default.
+#   [*location_allow*]      - Array: Locations to allow connections from.
+#   [*location_deny*]       - Array: Locations to deny connections from.
+#   [*ipv6_enable*]         - BOOL value to enable/disable IPv6 support
+#     (false|true). Module will check to see if IPv6 support exists on your
+#     system before enabling.
+#   [*ipv6_listen_ip*]      - Default IPv6 Address for NGINX to listen with
+#     this streamhost on. Defaults to all interfaces (::)
+#   [*ipv6_listen_port*]    - Default IPv6 Port for NGINX to listen with this
+#     streamhost on. Defaults to TCP 80
+#   [*ipv6_listen_options*] - Extra options for listen directive like 'default'
+#     to catchall. Template will allways add ipv6only=on. While issue
+#     jfryman/puppet-nginx#30 is discussed, default value is 'default'.
+#   [*add_header*]          - Hash: Adds headers to the HTTP response when
+#     response code is equal to 200, 204, 301, 302 or 304.
+#   [*index_files*]         - Default index files for NGINX to read when
+#     traversing a directory
+#   [*autoindex*]           - Set it on 'on' or 'off 'to activate/deactivate
+#                             autoindex directory listing. Undef by default.
+#   [*proxy*]               - Proxy server(s) for the root location to connect
+#     to.  Accepts a single value, can be used in conjunction with
+#     nginx::resource::upstream
+#   [*proxy_read_timeout*]  - Override the default the proxy read timeout value
+#     of 90 seconds
+#   [*proxy_redirect*]      - Override the default proxy_redirect value of off.
+#   [*resolver*]            - Array: Configures name servers used to resolve
+#     names of upstream servers into addresses.
+#   [*server_name*]         - List of streamhost names for which this streamhost will
+#     respond. Default [$name].
+#   [*raw_prepend*]            - A single string, or an array of strings to
+#     prepend to the server directive (after cfg prepend directives). NOTE:
+#     YOU are responsible for a semicolon on each line that requires one.
+#   [*raw_append*]             - A single string, or an array of strings to
+#     append to the server directive (after cfg append directives). NOTE:
+#     YOU are responsible for a semicolon on each line that requires one.
+#   [*owner*]                   - Defines owner of the .conf file
+#   [*group*]                   - Defines group of the .conf file
+#   [*mode*]                    - Defines mode of the .conf file
+#                                 Default to return 503
+# Actions:
+#
+# Requires:
+#
+# Sample Usage:
+#  nginx::resource::streamhost { 'test2.local':
+#    ensure   => present,
+#  }
+define nginx::resource::streamhost (
+  $ensure                       = 'present',
+  $listen_ip                    = '*',
+  $listen_port                  = '80',
+  $listen_options               = undef,
+  $ipv6_enable                  = false,
+  $ipv6_listen_ip               = '::',
+  $ipv6_listen_port             = '80',
+  $ipv6_listen_options          = 'default ipv6only=on',
+  $proxy,
+  $proxy_read_timeout           = $::nginx::config::proxy_read_timeout,
+  $proxy_connect_timeout        = $::nginx::config::proxy_connect_timeout,
+  $resolver                     = [],
+  $server_name                  = [$name],
+  $raw_prepend                  = undef,
+  $raw_append                   = undef,
+  $owner                        = $::nginx::config::global_owner,
+  $group                        = $::nginx::config::global_group,
+  $mode                         = $::nginx::config::global_mode,
+) {
+
+  validate_re($ensure, '^(present|absent)$',
+    "${ensure} is not supported for ensure. Allowed values are 'present' and 'absent'.")
+  if !(is_array($listen_ip) or is_string($listen_ip)) {
+    fail('$listen_ip must be a string or array.')
+  }
+  if !is_integer($listen_port) {
+    fail('$listen_port must be an integer.')
+  }
+  if ($listen_options != undef) {
+    validate_string($listen_options)
+  }
+  validate_bool($ipv6_enable)
+  if !(is_array($ipv6_listen_ip) or is_string($ipv6_listen_ip)) {
+    fail('$ipv6_listen_ip must be a string or array.')
+  }
+  if !is_integer($ipv6_listen_port) {
+    fail('$ipv6_listen_port must be an integer.')
+  }
+  validate_string($ipv6_listen_options)
+
+  validate_string($proxy_read_timeout)
+  validate_string($proxy_redirect)
+
+  validate_array($resolver)
+  validate_array($server_name)
+
+  validate_string($owner)
+  validate_string($group)
+  validate_re($mode, '^\d{4}$',
+    "${mode} is not valid. It should be 4 digits (0644 by default).")
+
+  # Variables
+  $streamhost_dir = "${::nginx::config::conf_dir}/streams-available"
+  $streamhost_enable_dir = "${::nginx::config::conf_dir}/streams-enabled"
+  $streamhost_symlink_ensure = $ensure ? {
+    'absent' => absent,
+    default  => 'link',
+  }
+
+  $name_sanitized = regsubst($name, ' ', '_', 'G')
+  $config_file = "${streamhost_dir}/${name_sanitized}.conf"
+
+  File {
+    ensure => $ensure ? {
+      'absent' => absent,
+      default  => 'file',
+    },
+    notify => Class['::nginx::service'],
+    owner  => $owner,
+    group  => $group,
+    mode   => $mode,
+  }
+
+  # Add IPv6 Logic Check - Nginx service will not start if ipv6 is enabled
+  # and support does not exist for it in the kernel.
+  if ($ipv6_enable == true) and (!$::ipaddress6) {
+    warning('nginx: IPv6 support is not enabled or configured properly')
+  }
+
+  concat { $config_file:
+    owner  => $owner,
+    group  => $group,
+    mode   => $mode,
+    notify => Class['::nginx::service'],
+  }
+
+  concat::fragment { "${name_sanitized}-header":
+    target  => $config_file,
+    content => template('nginx/streamhost/streamhost.erb'),
+    order   => '001',
+  }
+
+  file{ "${name_sanitized}.conf symlink":
+    ensure  => $streamhost_symlink_ensure,
+    path    => "${streamhost_enable_dir}/${name_sanitized}.conf",
+    target  => $config_file,
+    require => Concat[$config_file],
+    notify  => Class['::nginx::service'],
+  }
+
+}

--- a/manifests/resource/streamhost.pp
+++ b/manifests/resource/streamhost.pp
@@ -66,7 +66,7 @@ define nginx::resource::streamhost (
   $ipv6_listen_ip               = '::',
   $ipv6_listen_port             = '80',
   $ipv6_listen_options          = 'default ipv6only=on',
-  $proxy,
+  $proxy                        = undef,
   $proxy_read_timeout           = $::nginx::config::proxy_read_timeout,
   $proxy_connect_timeout        = $::nginx::config::proxy_connect_timeout,
   $resolver                     = [],
@@ -99,7 +99,6 @@ define nginx::resource::streamhost (
   validate_string($ipv6_listen_options)
 
   validate_string($proxy_read_timeout)
-  validate_string($proxy_redirect)
 
   validate_array($resolver)
   validate_array($server_name)

--- a/spec/defines/resource_stream_spec.rb
+++ b/spec/defines/resource_stream_spec.rb
@@ -1,0 +1,138 @@
+require 'spec_helper'
+
+describe 'nginx::resource::streamhost' do
+  let :title do
+    'www.rspec.example.com'
+  end
+  let :default_params do
+    {
+      :ipv6_enable => true,
+    }
+  end
+  let :facts do
+    {
+      :ipaddress6      => '::',
+    }
+  end
+  let :pre_condition do
+    [
+      'include ::nginx::config',
+    ]
+  end
+
+  describe 'os-independent items' do
+
+    describe 'basic assumptions' do
+      let :params do default_params end
+      it { is_expected.to contain_class("nginx::config") }
+      it { is_expected.to contain_concat("/etc/nginx/streams-available/#{title}.conf").with({
+        'owner' => 'root',
+        'group' => 'root',
+        'mode'  => '0644',
+      })}
+      it { is_expected.to contain_file("#{title}.conf symlink").with({
+        'ensure' => 'link',
+        'path'   => "/etc/nginx/streams-enabled/#{title}.conf",
+        'target' => "/etc/nginx/streams-available/#{title}.conf"
+      })}
+    end
+
+    describe "vhost_header template content" do
+      [
+        {
+          :title => 'should set the IPv4 listen IP',
+          :attr  => 'listen_ip',
+          :value => '127.0.0.1',
+          :match => %r'\s+listen\s+127.0.0.1:80;',
+        },
+        {
+          :title => 'should set the IPv4 listen port',
+          :attr  => 'listen_port',
+          :value => 45,
+          :match => %r'\s+listen\s+\*:45;',
+        },
+        {
+          :title => 'should set the IPv4 listen options',
+          :attr  => 'listen_options',
+          :value => 'spdy default',
+          :match => %r'\s+listen\s+\*:80 spdy default;',
+        },
+        {
+          :title => 'should enable IPv6',
+          :attr  => 'ipv6_enable',
+          :value => true,
+          :match => %r'\s+listen\s+\[::\]:80 default ipv6only=on;',
+        },
+        {
+          :title    => 'should not enable IPv6',
+          :attr     => 'ipv6_enable',
+          :value    => false,
+          :notmatch => %r'\slisten \[::\]:80 default ipv6only=on;',
+        },
+        {
+          :title => 'should set the IPv6 listen IP',
+          :attr  => 'ipv6_listen_ip',
+          :value => '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+          :match => %r'\s+listen\s+\[2001:0db8:85a3:0000:0000:8a2e:0370:7334\]:80 default ipv6only=on;',
+        },
+        {
+          :title => 'should set the IPv6 listen port',
+          :attr  => 'ipv6_listen_port',
+          :value => 45,
+          :match => %r'\s+listen\s+\[::\]:45 default ipv6only=on;',
+        },
+        {
+          :title => 'should set the IPv6 listen options',
+          :attr  => 'ipv6_listen_options',
+          :value => 'spdy',
+          :match => %r'\s+listen\s+\[::\]:80 spdy;',
+        },
+        {
+          :title => 'should set servername(s)',
+          :attr  => 'server_name',
+          :value => ['www.foo.com','foo.com'],
+          :match => %r'\s+server_name\s+www.foo.com foo.com;',
+        },
+        {
+          :title => 'should contain raw_prepend directives',
+          :attr  => 'raw_prepend',
+          :value => [
+            'if (a) {',
+            '  b;',
+            '}'
+          ],
+          :match => /^\s+if \(a\) {\n\s++b;\n\s+\}/,
+        },
+        {
+          :title => 'should contain raw_append directives',
+          :attr  => 'raw_append',
+          :value => [
+            'if (a) {',
+            '  b;',
+            '}'
+          ],
+          :match => /^\s+if \(a\) {\n\s++b;\n\s+\}/,
+        },
+      ].each do |param|
+        context "when #{param[:attr]} is #{param[:value]}" do
+          let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
+
+          it { is_expected.to contain_concat__fragment("#{title}-header") }
+          it param[:title] do
+            matches  = Array(param[:match])
+
+            if matches.all? { |m| m.is_a? Regexp }
+              matches.each { |item| is_expected.to contain_concat__fragment("#{title}-header").with_content(item) }
+            else
+              lines = catalogue.resource('concat::fragment', "#{title}-header").send(:parameters)[:content].split("\n")
+              expect(lines & Array(param[:match])).to eq(Array(param[:match]))
+            end
+            Array(param[:notmatch]).each do |item|
+              is_expected.to contain_concat__fragment("#{title}-header").without_content(item)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -147,3 +147,8 @@ mail {
   include <%= @conf_dir %>/conf.mail.d/*.conf;
 }
 <% end -%>
+<% if @stream -%>
+stream {
+  include <%= @conf_dir %>/conf.stream.d/*.conf;
+}
+<% end -%>

--- a/templates/streamhost/streamhost.erb
+++ b/templates/streamhost/streamhost.erb
@@ -1,0 +1,32 @@
+server {
+<%- if @listen_ip.is_a?(Array) then -%>
+  <%- @listen_ip.each do |ip| -%>
+  listen                <%= ip %>:<%= @listen_port %><% if @listen_options %> <%= @listen_options %><% end %>;
+  <%- end -%>
+<%- else -%>
+  listen                <%= @listen_ip %>:<%= @listen_port %><% if @listen_options %> <%= @listen_options %><% end %>;
+<%- end -%>
+<%# check to see if ipv6 support exists in the kernel before applying -%>
+<%- if @ipv6_enable && (defined? @ipaddress6) -%>
+  <%- if @ipv6_listen_ip.is_a?(Array) then -%>
+    <%- @ipv6_listen_ip.each do |ipv6| -%>
+  listen [<%= ipv6 %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
+    <%- end -%>
+  <%- else -%>
+  listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
+  <%- end -%>
+<%- end -%>
+  server_name           <%= @server_name.join(" ") %>;
+
+  <% Array(@raw_prepend).each do |line| -%>
+    <%= line %>
+  <% end %>
+
+  proxy_timeout         <%= @proxy_read_timeout %>;
+  proxy_connect_timeout <%= @proxy_connect_timeout %>;
+  proxy_pass            <%= @proxy %>;
+
+  <% Array(@raw_append).each do |line| -%>
+    <%= line %>
+  <% end -%>
+}


### PR DESCRIPTION
Adding support for stream configuration within NGINX.  Most of the code is copied from existing classes with parameters adjusted accordingly.  Mainly added a flag to the upstream configuration of http|stream so upstreams can be targeted to the appropriate context with http being the default value for backwards compatibility.