### PR TITLE
Adding a QuickStart Guide to the NGINX Module

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -23,7 +23,8 @@ This module manages NGINX configuration.
 
 ### Additional Documentation
 
-* [A Quickstart Guide to the NGINX Puppet Module][https://github.com/jfryman/puppet-nginx/blob/master/docs/quickstart.md]
+* [A Quickstart Guide to the NGINX Puppet Module][quickstart]
+[quickstart]: https://github.com/jfryman/puppet-nginx/blob/master/docs/quickstart.md
 
 
 ### Install and bootstrap an NGINX instance

--- a/README.markdown
+++ b/README.markdown
@@ -15,13 +15,16 @@ Forge](http://img.shields.io/puppetforge/v/jfryman/nginx.svg)](https://forge.pup
 
 This module manages NGINX configuration.
 
-## Quick Start
-
 ### Requirements
 
 * Puppet-2.7.0 or later
 * Facter 1.7.0 or later
 * Ruby-1.9.3 or later (Support for Ruby-1.8.7 is not guaranteed. YMMV).
+
+### Additional Documentation
+
+* [A Quickstart Guide to the NGINX Puppet Module]['/docs/quickstart.md']
+
 
 ### Install and bootstrap an NGINX instance
 
@@ -29,7 +32,7 @@ This module manages NGINX configuration.
 class { 'nginx': }
 ```
 
-### Setup a new virtual host
+### Creating a new virtual host
 
 ```puppet
 nginx::resource::vhost { 'www.puppetlabs.com':
@@ -52,6 +55,9 @@ nginx::resource::vhost { 'rack.puppetlabs.com':
   proxy => 'http://puppet_rack_app',
 }
 ```
+
+
+
 
 ### Add a smtp proxy
 

--- a/README.markdown
+++ b/README.markdown
@@ -23,7 +23,7 @@ This module manages NGINX configuration.
 
 ### Additional Documentation
 
-* [A Quickstart Guide to the NGINX Puppet Module]['https://github.com/jfryman/puppet-nginx/blob/master/docs/quickstart.md']
+* [A Quickstart Guide to the NGINX Puppet Module][https://github.com/jfryman/puppet-nginx/blob/master/docs/quickstart.md]
 
 
 ### Install and bootstrap an NGINX instance

--- a/README.markdown
+++ b/README.markdown
@@ -23,7 +23,7 @@ This module manages NGINX configuration.
 
 ### Additional Documentation
 
-* [A Quickstart Guide to the NGINX Puppet Module]['/docs/quickstart.md']
+* [A Quickstart Guide to the NGINX Puppet Module]['https://github.com/jfryman/puppet-nginx/blob/master/docs/quickstart.md']
 
 
 ### Install and bootstrap an NGINX instance

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -43,12 +43,75 @@ Calling the `nginx` class from your manifest simply installs the NGINX software 
     www_root => '/opt/html/',
   }
 ```
-In this example, the DNS address `www.myhost.com` will serve pages from the `/opt/html` directory.
+In this example, the DNS address `www.myhost.com` will serve pages from the `/opt/html` directory.  The module creates some sensible defaults (such as a root location and the choice of port `*:80) with this simple definition.
 
-### Defining 
+### Defining a Proxy
 
+Setting up a simple static webserver is straightforward, but is usually not the reason we implement NGINX to serve our web applications.  NGINX is a powerful *proxy* server that can manage large numbers of connections to one or more services that can serve dynamic web applications or even provide a simple technque for load balancing requests between multiple webservers.  For this example, let's define a proxy that serves a resource from a directory on our website. (A common use of this redirect may be to define a 'blog' link or a third party web application from your main site.)  We can define this proxy as follows:
 
-[nginx]: http://nginx.org
+```
+  nginx::resource::location{'/blog':
+    proxy => 'http://192.168.99.1/' ,
+    vhost => 'www.myhost.com'
+   }
+```
+This will proxy any requests made to `http://www.myhost.com/blog` to the URL `http://192.168.99.1/`.  Pay special attention to the use of `/` at the end of the URL we are proxying to - that will allow your query parameters or subfolder structure on your secondary webserver to remain intact.  
+
+### Defining Backend Resources
+
+We can expand on these simple proxies by defining *upstream* resources for our web applications.  Defining upstream resources allow us to define more complex scenarios such as configuration parameters, load balancing, or even the ability to share resources between virtual hosts. An upstream resource is defined with the `nginx::resource::upstream` class.  We can define a simple upstream resource by naming the resource and a single *member*.  To define an upstream resource for our previous proxy example, declare a class of type `nginx::resource::upstream` named `upstream_app`:
+
+```
+  nginx::resource::upstream { 'upstream_app':
+    members => [
+      '192.168.99.1:80',
+    ],
+  }
+  ```
+  This will define an upstream resource with our server IP of `192.168.99.1`.  To use the upstream in our previous proxy, modify the location block as follows:
+  
+  ```
+    nginx::resource::location{'/blog':
+    proxy => 'http://upstream_app/' ,
+    vhost => 'www.myhost.com'
+   }
+```
+Now `/blog` will proxy requests to services defined in our `upstream_app` resource.
+
+### Putting the pieces together
+
+Combining our configurations above into a single manifest, our code block looks like this:
+
+```
+  class{"nginx":
+    manage_repo => true,
+    package_source => 'nginx-mainline'
+
+}
+
+  nginx::resource::upstream { 'upstream_app':
+    members => [
+      '192.168.99.1:80',
+    ],
+  }
+
+  nginx::resource::vhost{'www.myhost.com':
+    www_root => '/opt/html/',
+  }
+
+  nginx::resource::location{'/proxy':
+    proxy => 'http://upstream_app/' ,
+    vhost => 'www.myhost.com',
+
+  }
+```  
+
+This puppet code block will:
+* Install the latest version of nginx from the 'mainline' nginx distributino.
+* Define a virtual host `www.myhost.com` for our website.
+* Define an *upstream* service that consists of a single external IP address.
+* Define a URL that will proxy to the upstream resource.  In this case,  `http://www.myhost.com/blog` will proxy to an external resource hosted at `http://192.168.99.1`.
+
 [phpfpm]: http://php-fpm.org
 [nginxpackages]: http://nginx.org/packages/mainline
 [nginxdocs]: http://nginx.org/en/docs/

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,57 @@
+# A QuickStart Guide to the NGINX Module
+
+The goal of this module is to simplify the deployment and management of 
+
+## Why NGINX?
+
+Before going too far, make sure that the [NGINX][] web server is appropriate for your needs. NGINX 
+was designed to be a scalable web and proxy server with the abiilty to handle 
+thousands of concurrent connections, but it is not designed to manage dynamic content.  For dynamic 
+web applications, NGINX must be configured to _proxy_ connections to a different process.  For 
+example, a PHP application in the common "LAMP Stack" configuration with Apache and PHP only requires a 
+few dynamic modules and configuration changes.  Running the same application with an NGINX infrastructure
+ requires the configuration of a NGINX proxy layer and a secondary runtime such as [PHP-FPM][phpfpm]. This
+ can add complexity to setting up the infrastructure, but it does allow you to scale application layers
+ independently.  For a good comparison of how NGINX differs from Apache, [DigitalOcean][] published 
+ a [good article][nginxvsapache] detailing some of the differences between the two.
+ 
+**NOTE**:  At this point, the module only supports Debian or RedHat based linux distributions.
+
+## Basic NGINX Installation and Configuration
+
+Installing NGINX and setting up your first web host is relatively straightforward.  To install
+NGINX with the puppet module, simply call the class in a puppet manifest:
+```
+   class{'nginx': }
+```
+This will install the NGINX package from the software repository of your Linux distribution, which can often be quite dated.  If you would like to install NGINX from repositories maintained by the NGINX project directly, allow the `nginx` class to manage package repositories:
+
+```
+class{'nginx':
+    manage_repo => true,
+    package_source => 'nginx-mainline'
+}
+```
+The choices here are `nginx-stable` (the current 'production' level release) and `nginx-mainline` (where active development is occuring) - you can read a full explanation of the differences [here][nginxpackages].  
+
+### Creating Your First Virtual Host
+
+Calling the `nginx` class from your manifest simply installs the NGINX software and puts some basic configuration in place.  In this state, NGINX will not serve web pages or proxy to other services - for that, we need to define a *server*.  In NGINX terminology, a *server* is how we define our services (such as websites) with a name.  (If you are used to configuring Apache, a server is identical to an Apache *virtual host*.)  A simple virtual host that serves static web pages can be defined with a server name and a *web root*, or the directory where our HTML pages are located.
+
+```
+  nginx::resource::vhost{'www.myhost.com':
+    www_root => '/opt/html/',
+  }
+```
+In this example, the DNS address `www.myhost.com` will serve pages from the `/opt/html` directory.
+
+### Defining 
+
+
+[nginx]: http://nginx.org
+[phpfpm]: http://php-fpm.org
+[nginxpackages]: http://nginx.org/packages/mainline
+[nginxdocs]: http://nginx.org/en/docs/
+[puppetlabsapache]: https://forge.puppetlabs.com/puppetlabs/apache
+[digitalocean]: https://www.digitalocean.com
+[nginxvsapache]: https://www.digitalocean.com/community/tutorials/apache-vs-nginx-practical-considerations

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,21 +1,4 @@
-# A QuickStart Guide to the NGINX Module
-
-The goal of this module is to simplify the deployment and management of 
-
-## Why NGINX?
-
-Before going too far, make sure that the [NGINX][] web server is appropriate for your needs. NGINX 
-was designed to be a scalable web and proxy server with the abiilty to handle 
-thousands of concurrent connections, but it is not designed to manage dynamic content.  For dynamic 
-web applications, NGINX must be configured to _proxy_ connections to a different process.  For 
-example, a PHP application in the common "LAMP Stack" configuration with Apache and PHP only requires a 
-few dynamic modules and configuration changes.  Running the same application with an NGINX infrastructure
- requires the configuration of a NGINX proxy layer and a secondary runtime such as [PHP-FPM][phpfpm]. This
- can add complexity to setting up the infrastructure, but it does allow you to scale application layers
- independently.  For a good comparison of how NGINX differs from Apache, [DigitalOcean][] published 
- a [good article][nginxvsapache] detailing some of the differences between the two.
- 
-**NOTE**:  At this point, the module only supports Debian or RedHat based linux distributions.
+# A QuickStart Guide to the NGINX Puppet Module
 
 ## Basic NGINX Installation and Configuration
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -89,14 +89,20 @@ Combining our configurations above into a single manifest, our code block looks 
   }
 ```  
 
-This puppet code block will:
+In summary, this puppet code block will:
 * Install the latest version of nginx from the 'mainline' nginx distributino.
 * Define a virtual host `www.myhost.com` for our website.
 * Define an *upstream* service that consists of a single external IP address.
 * Define a URL that will proxy to the upstream resource.  In this case,  `http://www.myhost.com/blog` will proxy to an external resource hosted at `http://192.168.99.1`.
 
+## References
+There are a number of resources available for learning how to use NGINX effectively.  Here are a few that you may find useful:
+[nginx.org][nginx]:  The NGNIX homepage.
+[NGINX Documentation][ngixdocs]: Open Source NGINX Documentation
+[NGINX vs. Apache][nginxvsapache]: A good article from [DigitalOcean][] describing the key differences between the use and architecture of NGINX vs. the Apache HTTPD server.  This is a good article if you are new to NGINX or want a simple overview of the NGINX event driven architecture.
+
+[nginx]: http://ngnix.org
 [phpfpm]: http://php-fpm.org
-[nginxpackages]: http://nginx.org/packages/mainline
 [nginxdocs]: http://nginx.org/en/docs/
 [puppetlabsapache]: https://forge.puppetlabs.com/puppetlabs/apache
 [digitalocean]: https://www.digitalocean.com


### PR DESCRIPTION
I've written a bit of documentation regarding the NGINX Puppet module - mostly a 'quick start' guide or people who are either new to this module, or new to NGINX itself.  I have a couple of motivations for adding to the documentation:

1.  I have used this module *a lot* - it's been very helpful in managing the infrastructure I manage day-to-day.  I am, of course, grateful for the work the contributors have put in to the module and I also want to encourage use (and reuse) as I've seen people jump into creating hard-to-reuse manifests because they didn't understand this module or how to use it.  (Mostly by beginners.)

2.  I've written instructions similar to this a number of times - rather than continue that work, I'd like to contribute this quick guide to the project itself.

I hope you find this useful!