### PR TITLE
Update vhost proxy_set_header defaults to match location

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -197,7 +197,7 @@ define nginx::resource::vhost (
   $proxy_redirect               = undef,
   $proxy_read_timeout           = $::nginx::config::proxy_read_timeout,
   $proxy_connect_timeout        = $::nginx::config::proxy_connect_timeout,
-  $proxy_set_header             = [],
+  $proxy_set_header             = $::nginx::config::proxy_set_header,
   $proxy_cache                  = false,
   $proxy_cache_key              = undef,
   $proxy_cache_use_stale        = undef,


### PR DESCRIPTION
`nginx::resource::location` defaults this value to
`$::nginx::config::proxy_set_headers`, whereas `nginx::resource::vhost`
defaults it to `[]`. This means that you get a different set of defaults
if you use an explicit `nginx::resource::location` resource as opposed to
setting it up via an `nginx::resource::vhost` with a proxy attribute.

Updating this default value to be consistent will be less surprising.