### PR TITLE
Make the name of the upstream that appears in the conf.d file configurable

### DIFF
--- a/manifests/resource/upstream.pp
+++ b/manifests/resource/upstream.pp
@@ -9,6 +9,7 @@
 #   [*upstream_cfg_prepend*]  - It expects a hash with custom directives to put before anything else inside upstream
 #   [*upstream_fail_timeout*] - Set the fail_timeout for the upstream. Default is 10 seconds - As that is what Nginx does normally.
 #   [*upstream_max_fails*]    - Set the max_fails for the upstream. Default is to use nginx default value which is 1.
+#   [*upstream_name*]         - Set the upstream name that appears in the generated conf.d file. Default is namevar.
 #
 # Actions:
 #
@@ -46,6 +47,7 @@ define nginx::resource::upstream (
   $upstream_fail_timeout = '10s',
   $upstream_max_fails = undef,
   $upstream_context = 'http',
+  $upstream_name = $name,
 ) {
 
   if $members != undef {

--- a/spec/defines/resource_upstream_spec.rb
+++ b/spec/defines/resource_upstream_spec.rb
@@ -28,7 +28,7 @@ describe 'nginx::resource::upstream' do
       let :params do default_params end
 
       it { is_expected.to contain_concat("/etc/nginx/conf.d/#{title}-upstream.conf") }
-      it { is_expected.to contain_concat__fragment("#{title}_upstream_header").with_content(/upstream #{title}/) }
+      it { is_expected.to contain_concat__fragment("#{title}_upstream_header").with_content(/upstream #{params[:upstream_name]}/) }
 
       it {
         is_expected.to contain_concat__fragment("#{title}_upstream_header").with(

--- a/templates/conf.d/upstream_header.erb
+++ b/templates/conf.d/upstream_header.erb
@@ -1,4 +1,4 @@
-upstream <%= @name %> {
+upstream <%= @upstream_name %> {
 <% if @upstream_cfg_prepend -%><% @upstream_cfg_prepend.sort_by{|k,v| k}.each do |key,value| %>
 <% if value.is_a?(Hash) -%><% value.each do |subkey,subvalue| -%>
 <% Array(subvalue).each do |asubvalue| -%>


### PR DESCRIPTION
Make the name that appears in the nginx configuration independent of the
namevar known to puppet. This is useful when using exported resources,
if you want to have the same upstream names in the config file on multiple independent
clusters exporting to the same puppetdb.

Also, modify spec for upstreams to test for proper string after upstream_name param addition