### PR TITLE
Replaced restart by reload

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -110,7 +110,7 @@ class nginx (
   $configtest_enable              = false,
   $service_ensure                 = running,
   $service_flags                  = undef,
-  $service_restart                = '/etc/init.d/nginx configtest && /etc/init.d/nginx restart',
+  $service_restart                = '/etc/init.d/nginx reload',
   $service_name                   = undef,
   ### END Service Configuration ###
 


### PR DESCRIPTION
It may be better to reload instead of restart to prevent broken connections on production environment.

From official nginx doc:
Once the master process receives the signal to reload configuration, it checks the syntax validity of the new configuration file and tries to apply the configuration provided in it. If this is a success, the master process starts new worker processes and sends messages to old worker processes, requesting them to shut down. Otherwise, the master process rolls back the changes and continues to work with the old configuration. Old worker processes, receiving a command to shut down, stop accepting new connections and continue to service current requests until all such requests are serviced. After that, the old worker processes exit.