### PR TITLE
Ensure isn't being respected on locations.

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -380,6 +380,7 @@ define nginx::resource::location (
     $tmpFile=md5("${vhost_sanitized}-${priority}-${location_sanitized}")
 
     concat::fragment { $tmpFile:
+      ensure  => $ensure_real,
       target  => $config_file,
       content => join([
         template('nginx/vhost/location_header.erb'),
@@ -396,6 +397,7 @@ define nginx::resource::location (
 
     $sslTmpFile=md5("${vhost_sanitized}-${ssl_priority}-${location_sanitized}-ssl")
     concat::fragment { $sslTmpFile:
+      ensure  => $ensure_real,
       target  => $config_file,
       content => join([
         template('nginx/vhost/location_header.erb'),


### PR DESCRIPTION
This is PR #676 reborn.   Ensure isn't currently respected on location resources, so they don't get deleted from stored configs.