### PR TITLE
Add unix socket for listening.

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -11,6 +11,12 @@
 #     vHost on. Defaults to TCP 80
 #   [*listen_options*]      - Extra options for listen directive like
 #     'default' to catchall. Undef by default.
+#   [*listen_unix_socket_enable*] - BOOL value to enable/disable UNIX socket
+#     listening support (false|true).
+#   [*listen_unix_socket*]  - Default unix socket for NGINX to listen with this
+#     vHost on. Defaults to UNIX /var/run/nginx.sock
+#   [*listen_unix_socket_options*] - Extra options for listen directive like
+#     'default' to catchall. Undef by default.
 #   [*location_allow*]      - Array: Locations to allow connections from.
 #   [*location_deny*]       - Array: Locations to deny connections from.
 #   [*ipv6_enable*]         - BOOL value to enable/disable IPv6 support
@@ -168,6 +174,9 @@ define nginx::resource::vhost (
   $listen_ip                    = '*',
   $listen_port                  = '80',
   $listen_options               = undef,
+  $listen_unix_socket_enable    = false,
+  $listen_unix_socket           = '/var/run/nginx.sock',
+  $listen_unix_socket_options   = undef,
   $location_allow               = [],
   $location_deny                = [],
   $ipv6_enable                  = false,
@@ -271,6 +280,13 @@ define nginx::resource::vhost (
   }
   if ($listen_options != undef) {
     validate_string($listen_options)
+  }
+  validate_bool($listen_unix_socket_enable)
+  if !(is_array($listen_unix_socket) or is_string($listen_unix_socket)) {
+    fail('$listen_unix_socket must be a string or array.')
+  }
+  if ($listen_unix_socket_options != undef) {
+    validate_string($listen_unix_socket_options)
   }
   validate_array($location_allow)
   validate_array($location_deny)

--- a/spec/defines/resource_vhost_spec.rb
+++ b/spec/defines/resource_vhost_spec.rb
@@ -8,6 +8,7 @@ describe 'nginx::resource::vhost' do
     {
       :www_root    => '/',
       :ipv6_enable => true,
+      :listen_unix_socket_enable => true,
     }
   end
   let :facts do
@@ -112,6 +113,30 @@ describe 'nginx::resource::vhost' do
           :attr  => 'ipv6_listen_options',
           :value => 'spdy',
           :match => %r'\s+listen\s+\[::\]:80 spdy;',
+        },
+        {
+          :title => 'should enable listening on unix socket',
+          :attr  => 'listen_unix_socket_enable',
+          :value => true,
+          :match => %r'\s+listen\s+unix:/var/run/nginx\.sock;',
+        },
+        {
+          :title    => 'should not enable listening on unix socket',
+          :attr     => 'listen_unix_socket_enable',
+          :value    => false,
+          :notmatch => %r'\s+listen\s+unix:/var/run/nginx\.sock;',
+        },
+        {
+          :title => 'should set the listen unix socket',
+          :attr  => 'listen_unix_socket',
+          :value => '/var/run/puppet_nginx.sock',
+          :match => %r'\s+listen\s+unix:/var/run/puppet_nginx\.sock;',
+        },
+        {
+          :title => 'should set the listen unix socket options',
+          :attr  => 'listen_unix_socket_options',
+          :value => 'spdy',
+          :match => %r'\s+listen\s+unix:/var/run/nginx\.sock spdy;',
         },
         {
           :title => 'should set servername(s)',

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -8,6 +8,15 @@ server {
   <%- else -%>
   listen       <%= @listen_ip %>:<%= @listen_port %><% if @listen_options %> <%= @listen_options %><% end %>;
   <%- end -%>
+  <%- if @listen_unix_socket_enable -%>
+    <%- if @listen_unix_socket.is_a?(Array) then -%>
+      <%- @listen_unix_socket.each do |unix_socket| -%>
+  listen unix:<%= unix_socket %><% if @listen_unix_socket_options %> <%= @listen_unix_socket_options %><% end %>;
+      <%- end -%>
+    <%- else -%>
+  listen unix:<%= @listen_unix_socket %><% if @listen_unix_socket_options %> <%= @listen_unix_socket_options %><% end %>;
+    <%- end -%>
+  <%- end -%>
 <%# check to see if ipv6 support exists in the kernel before applying -%>
   <%- if @ipv6_enable && (defined? @ipaddress6) -%>
     <%- if @ipv6_listen_ip.is_a?(Array) then -%>
@@ -31,6 +40,15 @@ server {
   <%- end -%>
 <%- else -%>
   listen <%= @listen_ip %>:<%= @listen_port %><% if @listen_options %> <%= @listen_options %><% end %>;
+<%- end -%>
+<%- if @listen_unix_socket_enable -%>
+  <%- if @listen_unix_socket.is_a?(Array) then -%>
+    <%- @listen_unix_socket.each do |unix_socket| -%>
+  listen unix:<%= unix_socket %><% if @listen_unix_socket_options %> <%= @listen_unix_socket_options %><% end %>;
+    <%- end -%>
+  <%- else -%>
+  listen unix:<%= @listen_unix_socket %><% if @listen_unix_socket_options %> <%= @listen_unix_socket_options %><% end %>;
+  <%- end -%>
 <%- end -%>
 <%# check to see if ipv6 support exists in the kernel before applying -%>
 <%- if @ipv6_enable && (defined? @ipaddress6) -%>


### PR DESCRIPTION
nginx can listen on unix sockets in addition to v4 and v6 addrs. This adds parameters to permit this use case.
http://nginx.org/en/docs/http/ngx_http_core_module.html#listen

The parameters emulate the ipv6 implementation. The enable parameter only affects listen in the unix socket case (not things like proxy_pass), so I called this listen_unix_socket_enable rather than unix_socket_enable.