### PR TITLE
Add parameter to allow setting error_log severity level

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -25,6 +25,7 @@ class nginx::config(
   $log_dir                        = $::nginx::params::log_dir,
   $http_access_log                = $::nginx::params::http_access_log,
   $nginx_error_log                = $::nginx::params::nginx_error_log,
+  $nginx_error_log_severity       = 'error',
   $pid                            = $::nginx::params::pid,
   $proxy_temp_path                = $::nginx::params::proxy_temp_path,
   $root_group                     = $::nginx::params::root_group,
@@ -169,6 +170,7 @@ class nginx::config(
   }
 
   validate_string($nginx_error_log)
+  validate_re($nginx_error_log_severity,['debug','info','notice','warn','error','crit','alert','emerg'],'$nginx_error_log_severity must be debug, info, notice, warn, error, crit, alert or emerg')
   validate_string($http_access_log)
   validate_string($proxy_headers_hash_bucket_size)
   validate_bool($super_user)

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -104,7 +104,13 @@ describe 'nginx::config' do
           :title => 'should set error_log',
           :attr  => 'nginx_error_log',
           :value => '/path/to/error.log',
-          :match => 'error_log  /path/to/error.log;',
+          :match => 'error_log  /path/to/error.log error;',
+        },
+        {
+          :title => 'should set error_log severity level',
+          :attr  => 'nginx_error_log_severity',
+          :value => 'warn',
+          :match => 'error_log  /var/log/nginx/error.log warn;',
         },
         {
             :title => 'should set pid',
@@ -559,6 +565,12 @@ describe 'nginx::config' do
       it { is_expected.to contain_file("/var/nginx/client_body_temp").with(:owner => 'www-data')}
       it { is_expected.to contain_file("/var/nginx/proxy_temp").with(:owner => 'www-data')}
       it { is_expected.to contain_file("/etc/nginx/nginx.conf").with_content %r{^user www-data;}}
+    end
+
+    context "when nginx_error_log_severity = invalid" do
+      let(:params) {{:nginx_error_log_severity => 'invalid'}}
+
+      it { expect { is_expected.to contain_class('nginx::config') }.to raise_error(Puppet::Error,/\$nginx_error_log_severity must be debug, info, notice, warn, error, crit, alert or emerg/) }
     end
   end
 end

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -9,7 +9,7 @@ worker_rlimit_nofile <%= @worker_rlimit_nofile %>;
 <% if @pid -%>
 pid        <%= @pid %>;
 <% end -%>
-error_log  <%= @nginx_error_log %>;
+error_log  <%= @nginx_error_log %> <%= @nginx_error_log_severity %>;
 
 <% if @nginx_cfg_prepend -%>
 <%- field_width = @nginx_cfg_prepend.inject(0) { |l,(k,v)| k.size > l ? k.size : l } -%>


### PR DESCRIPTION
This patch allows to set the severity level for error_log.
If not set it will use the default severity level of 'error'.
$nginx_error_log_severity is validated to only allow valid values.