### PR TITLE
added package_name to config class

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -35,6 +35,7 @@ class nginx::config(
   $super_user                     = $::nginx::params::super_user,
   $temp_dir                       = $::nginx::params::temp_dir,
   $vhost_purge                    = false,
+  $package_name                   = $::nginx::params::package_name,
 
   # Primary Templates
   $conf_template                  = 'nginx/conf.d/nginx.conf.erb',


### PR DESCRIPTION
Allows nginx-plus to be specified in Hiera (along with manage_repo = false)

I haven't added an "if package_name is nginx-plus then fail if manage_repo is true" statement but I can if required for this to be accepted.