### PR TITLE
File[undef] error: re-allowed vhost's www_root with location's proxy

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -325,9 +325,6 @@ define nginx::resource::location (
   if (($www_root == undef) and ($proxy == undef) and ($location_alias == undef) and ($stub_status == undef) and ($fastcgi == undef) and ($uwsgi == undef) and ($location_custom_cfg == undef) and ($internal == false)) {
     fail('Cannot create a location reference without a www_root, proxy, location_alias, fastcgi, uwsgi, stub_status, internal, or location_custom_cfg defined')
   }
-  if (($www_root != undef) and ($proxy != undef)) {
-    fail('Cannot define both directory and proxy in a virtual host')
-  }
 
   # Use proxy, fastcgi or uwsgi template if $proxy is defined, otherwise use directory template.
   # fastcgi_script is deprecated


### PR DESCRIPTION
Hello there.

This PR fixes a circumstance in Nginx' module configuration. The removed code did not allow a www_root for a vhost with a proxy in one of its locations, although it is allowed in nginx configurations. Configuring the vhost without a www_root to satisfy the location spec leads to an error in Puppet-Nginx main class, where an undefined File reference is not allowed. (The message is `Error: Parameter path failed on File[undef]: File paths must be fully qualified, not 'undef' at /tmp/vagrant-puppet/manifests-[hash]/nodes/Nginx.pp:187`