### PR TITLE
improved location ordering

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -376,10 +376,9 @@ define nginx::resource::location (
 
 
   ## Create stubs for vHost File Fragment Pattern
+  $location_md5 = md5($location)
   if ($ssl_only != true) {
-    $tmpFile=md5("${vhost_sanitized}-${priority}-${location_sanitized}")
-
-    concat::fragment { $tmpFile:
+    concat::fragment { "${vhost_sanitized}-${priority}-${location_md5}":
       ensure  => $ensure_real,
       target  => $config_file,
       content => join([
@@ -395,8 +394,7 @@ define nginx::resource::location (
   if ($ssl == true or $ssl_only == true) {
     $ssl_priority = $priority + 300
 
-    $sslTmpFile=md5("${vhost_sanitized}-${ssl_priority}-${location_sanitized}-ssl")
-    concat::fragment { $sslTmpFile:
+    concat::fragment { "${vhost_sanitized}-${ssl_priority}-${location_md5}-ssl":
       ensure  => $ensure_real,
       target  => $config_file,
       content => join([

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -20,7 +20,7 @@ describe 'nginx::resource::location' do
       } end
 
       it { is_expected.to contain_class("nginx::config") }
-      it { is_expected.to contain_concat__fragment("f25e14942fb58942ee13b1465a4e1719").with_content(/location rspec-test/) }
+      it { is_expected.to contain_concat__fragment("vhost1-500-33c6aa94600c830ad2d316bb4db36724").with_content(/location rspec-test/) }
       it { is_expected.not_to contain_file('/etc/nginx/fastcgi_params') }
       it { is_expected.not_to contain_concat__fragment("vhost1-800-rspec-test-ssl") }
       it { is_expected.not_to contain_file("/etc/nginx/rspec-test_htpasswd") }
@@ -165,10 +165,10 @@ describe 'nginx::resource::location' do
           let :default_params do { :location => 'location', :proxy => 'proxy_value', :vhost => 'vhost1' } end
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
 
-          it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
+          it { is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")) }
 
           it param[:title] do
-            fragment = Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")
+            fragment = "vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")
             matches  = Array(param[:match])
 
             if matches.all? { |m| m.is_a? Regexp }
@@ -179,7 +179,7 @@ describe 'nginx::resource::location' do
             end
 
             Array(param[:notmatch]).each do |item|
-              is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
+              is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")).without_content(item)
             end
           end
         end
@@ -242,10 +242,10 @@ describe 'nginx::resource::location' do
           let :default_params do { :location => 'location', :proxy => 'proxy_value', :vhost => 'vhost1' } end
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
 
-          it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
+          it { is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")) }
 
           it param[:title] do
-            fragment = Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")
+            fragment = "vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")
             matches  = Array(param[:match])
 
             if matches.all? { |m| m.is_a? Regexp }
@@ -256,12 +256,12 @@ describe 'nginx::resource::location' do
             end
 
             Array(param[:notmatch]).each do |item|
-              is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
+              is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")).without_content(item)
             end
           end
 
           it "should end with a closing brace" do
-            fragment = Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")
+            fragment = "vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")
             content = catalogue.resource('concat::fragment', fragment).send(:parameters)[:content]
             expect((content.split("\n").reject {|l| l =~ /^(\s*#|$)/ }.last).strip).to eq('}')
           end
@@ -276,27 +276,27 @@ describe 'nginx::resource::location' do
 
       context "when location_alias is 'value'" do
         let :params do default_params end
-        it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")) }
+        it { is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("location")) }
         it "should set alias" do
-          is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")).
+          is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("location")).
                   with_content(/^[ ]+alias\s+value;/)
         end
       end
 
       context "when autoindex is 'on'" do
         let :params do default_params.merge({ :autoindex => 'on' }) end
-        it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")) }
+        it { is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("location")) }
         it "should set autoindex" do
-          is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")).
+          is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("location")).
                   with_content(/^[ ]+autoindex\s+on;/)
         end
       end
 
       context "when autoindex is not set" do
         let :params do default_params end
-        it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")) }
+        it { is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("location")) }
         it "should not set autoindex" do
-          is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")).
+          is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("location")).
                   without_content(/^[ ]+autoindex[^;]+;/)
         end
       end
@@ -334,9 +334,9 @@ describe 'nginx::resource::location' do
         context "when #{param[:attr]} is #{param[:value]}" do
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
 
-          it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
+          it { is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")) }
           it param[:title] do
-            fragment = Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")
+            fragment = "vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")
             matches  = Array(param[:match])
 
             if matches.all? { |m| m.is_a? Regexp }
@@ -347,7 +347,7 @@ describe 'nginx::resource::location' do
             end
 
             Array(param[:notmatch]).each do |item|
-              is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
+              is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")).without_content(item)
             end
           end
         end
@@ -355,18 +355,18 @@ describe 'nginx::resource::location' do
 
       context "when autoindex is 'on'" do
         let :params do default_params.merge({ :autoindex => 'on' }) end
-        it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")) }
+        it { is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("location")) }
         it "should set autoindex" do
-          is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")).
+          is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("location")).
                   with_content(/^[ ]+autoindex\s+on;/)
         end
       end
 
       context "when autoindex is not set" do
         let :params do default_params end
-        it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")) }
+        it { is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("location")) }
         it "should not set autoindex" do
-          is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")).
+          is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("location")).
                   without_content(/^[ ]+autoindex[^;]+;/)
         end
       end
@@ -395,9 +395,9 @@ describe 'nginx::resource::location' do
           let :default_params do { :location => 'location', :location_custom_cfg => {'test1'=>'value1'}, :vhost => 'vhost1' } end
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
 
-          it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
+          it { is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")) }
           it param[:title] do
-            fragment = Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")
+            fragment = "vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")
             matches  = Array(param[:match])
 
             if matches.all? { |m| m.is_a? Regexp }
@@ -408,7 +408,7 @@ describe 'nginx::resource::location' do
             end
 
             Array(param[:notmatch]).each do |item|
-              is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
+              is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")).without_content(item)
             end
           end
         end
@@ -459,9 +459,9 @@ describe 'nginx::resource::location' do
         context "when #{param[:attr]} is #{param[:value]}" do
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
 
-          it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
+          it { is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")) }
           it param[:title] do
-            fragment = Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")
+            fragment = "vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")
             matches  = Array(param[:match])
 
             if matches.all? { |m| m.is_a? Regexp }
@@ -472,7 +472,7 @@ describe 'nginx::resource::location' do
             end
 
             Array(param[:notmatch]).each do |item|
-              is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
+              is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")).without_content(item)
             end
           end
         end
@@ -480,18 +480,18 @@ describe 'nginx::resource::location' do
 
       context "when fastcgi_script is 'value'" do
         let :params do default_params.merge({ :fastcgi_script => 'value' }) end
-        it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
+        it { is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")) }
         it "should set fastcgi_script" do
-          is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).
+          is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")).
                   with_content(%r|^[ ]+fastcgi_param\s+SCRIPT_FILENAME\s+value;|)
         end
       end
 
       context "when fastcgi_script is not set" do
         let :params do default_params end
-        it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
+        it { is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")) }
         it "should not set fastcgi_script" do
-          is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).
+          is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")).
                   without_content(/^[ ]+fastcgi_param\s+SCRIPT_FILENAME\s+.+?;/)
         end
       end
@@ -499,7 +499,7 @@ describe 'nginx::resource::location' do
       context "when fastcgi_param is {'CUSTOM_PARAM' => 'value'}" do
         let :params do default_params.merge({ :fastcgi_param => {'CUSTOM_PARAM' => 'value', 'CUSTOM_PARAM2' => 'value2'} }) end
         it "should set fastcgi_param" do
-        should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).
+        should contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")).
                   with_content(%r|fastcgi_param\s+CUSTOM_PARAM\s+value;|).
                   with_content(%r|fastcgi_param\s+CUSTOM_PARAM2\s+value2;|)
         end
@@ -508,12 +508,12 @@ describe 'nginx::resource::location' do
       context "when fastcgi_param is not set" do
         let :params do default_params end
         it "should not set fastcgi_param" do
-        should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).
+        should contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")).
                   without_content(/fastcgi_param\s+CUSTOM_PARAM\s+.+?;/).
                   without_content(/fastcgi_param\s+CUSTOM_PARAM2\s+.+?;/)
         end
         it "should not add comment # Enable custom fastcgi_params" do
-        should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).
+        should contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")).
                   without_content(/# Enable custom fastcgi_params\s+/)
         end
       end
@@ -557,9 +557,9 @@ describe 'nginx::resource::location' do
         context "when #{param[:attr]} is #{param[:value]}" do
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
 
-          it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
+          it { is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")) }
           it param[:title] do
-            fragment = Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")
+            fragment = "vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")
             matches  = Array(param[:match])
 
             if matches.all? { |m| m.is_a? Regexp }
@@ -570,7 +570,7 @@ describe 'nginx::resource::location' do
             end
 
             Array(param[:notmatch]).each do |item|
-              is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
+              is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")).without_content(item)
             end
           end
         end
@@ -666,9 +666,9 @@ describe 'nginx::resource::location' do
           let :default_params do { :location => 'location', :proxy => 'proxy_value', :vhost => 'vhost1' } end
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
 
-          it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
+          it { is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")) }
           it param[:title] do
-            fragment = Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")
+            fragment = "vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")
             matches  = Array(param[:match])
 
             if matches.all? { |m| m.is_a? Regexp }
@@ -679,7 +679,7 @@ describe 'nginx::resource::location' do
             end
 
             Array(param[:notmatch]).each do |item|
-              is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
+              is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")).without_content(item)
             end
           end
         end
@@ -694,14 +694,14 @@ describe 'nginx::resource::location' do
           :proxy_cache_valid => '10m',
         } end
 
-        it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")).with_content(/proxy_cache_valid\s+10m;/) }
+        it { is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("location")).with_content(/proxy_cache_valid\s+10m;/) }
       end
     end
 
     describe "vhost_location_stub_status template content" do
       let :params do { :location => 'location', :stub_status => true, :vhost => 'vhost1' }  end
       it do
-        is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).
+        is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("#{params[:location]}")).
                  with_content(/stub_status\s+on/)
       end
     end
@@ -722,25 +722,25 @@ describe 'nginx::resource::location' do
 
       context 'when ssl_only => true' do
         let :params do { :ssl_only => true, :vhost => 'vhost1', :www_root => '/', } end
-        it { is_expected.not_to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-rspec-test")) }
+        it { is_expected.not_to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("rspec-test")) }
       end
 
       context 'when ssl_only => false' do
         let :params do { :ssl_only => false, :vhost => 'vhost1', :www_root => '/', } end
 
-        it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-rspec-test")) }
+        it { is_expected.to contain_concat__fragment("vhost1-500-" + Digest::MD5.hexdigest("rspec-test")) }
       end
 
       context 'when ssl => true' do
         let :params do { :ssl => true, :vhost => 'vhost1', :www_root => '/', } end
 
-        it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-800-rspec-test-ssl")) }
+        it { is_expected.to contain_concat__fragment("vhost1-800-" + Digest::MD5.hexdigest("rspec-test") + "-ssl") }
       end
 
       context 'when ssl => false' do
         let :params do { :ssl => false, :vhost => 'vhost1', :www_root => '/', } end
 
-        it { is_expected.not_to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-800-rspec-test-ssl")) }
+        it { is_expected.not_to contain_concat__fragment("vhost1-800-" + Digest::MD5.hexdigest("rspec-test") + "-ssl") }
       end
 
       context "vhost missing" do
@@ -777,8 +777,8 @@ describe 'nginx::resource::location' do
           :ssl => true,
         } end
 
-        it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("www_rspec-vhost_com-500-www.rspec-location.com")).with_target('/etc/nginx/sites-available/www_rspec-vhost_com.conf') }
-        it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("www_rspec-vhost_com-800-www.rspec-location.com-ssl")).with_target('/etc/nginx/sites-available/www_rspec-vhost_com.conf') }
+        it { is_expected.to contain_concat__fragment("www_rspec-vhost_com-500-" + Digest::MD5.hexdigest("www.rspec-location.com")).with_target('/etc/nginx/sites-available/www_rspec-vhost_com.conf') }
+        it { is_expected.to contain_concat__fragment("www_rspec-vhost_com-800-" + Digest::MD5.hexdigest("www.rspec-location.com") + "-ssl").with_target('/etc/nginx/sites-available/www_rspec-vhost_com.conf') }
       end
     end
   end


### PR DESCRIPTION
This change orders locations the same way if a virtual host supports both http and https. Also if two virtual hosts have the same locations the ordering is identical.