### PR TITLE
new variable: http_raw_append for nginx.conf

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -63,6 +63,7 @@ class nginx::config(
   $gzip_types                     = 'text/html',
   $gzip_vary                      = 'off',
   $http_cfg_append                = false,
+  $http_raw_append                = false,
   $http_tcp_nodelay               = 'on',
   $http_tcp_nopush                = 'off',
   $keepalive_timeout              = '65',
@@ -166,6 +167,12 @@ class nginx::config(
   if ($http_cfg_append != false) {
     if !(is_hash($http_cfg_append) or is_array($http_cfg_append)) {
       fail('$http_cfg_append must be either a hash or array')
+    }
+  }
+
+  if ($http_raw_append != false) {
+    if !(is_array($http_raw_append)) {
+      fail('$http_raw_append must be an array')
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,7 @@ class nginx (
   $fastcgi_cache_use_stale        = undef,
   $gzip                           = undef,
   $http_cfg_append                = undef,
+  $http_raw_append                = undef,
   $http_tcp_nodelay               = undef,
   $http_tcp_nopush                = undef,
   $keepalive_timeout              = undef,
@@ -158,6 +159,7 @@ class nginx (
         $gzip or
         $http_access_log or
         $http_cfg_append or
+        $http_raw_append or
         $http_tcp_nodelay or
         $http_tcp_nopush or
         $keepalive_timeout or
@@ -239,6 +241,7 @@ class nginx (
       gzip                           => $gzip,
       http_access_log                => $http_access_log,
       http_cfg_append                => $http_cfg_append,
+      http_raw_append                => $http_raw_append,
       http_tcp_nodelay               => $http_tcp_nodelay,
       http_tcp_nopush                => $http_tcp_nopush,
       keepalive_timeout              => $keepalive_timeout,

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -132,8 +132,14 @@ http {
 <% if @fastcgi_cache_use_stale -%>
   fastcgi_cache_use_stale <%= @fastcgi_cache_use_stale %>;
 <% end -%>
-<% if @http_cfg_append -%>
 
+<% if @http_raw_append -%>
+  <% Array(@http_raw_append).each do |line| -%>
+    <%= line %>
+   <% end %>
+<% end -%>
+
+<% if @http_cfg_append -%>
   <%- field_width = @http_cfg_append.inject(0) { |l,(k,v)| k.size > l ? k.size : l } -%>
   <%- @http_cfg_append.sort_by{|k,v| k}.each do |key,value| -%>
   <%- Array(value).each do |asubvalue| -%>


### PR DESCRIPTION
I added a new variable for special configuration (raw). An example for ldap config:

#### Hieradata ###
nginx::http_raw_append:
  - 'ldap_server my_ldap {'
  - 'url ldap://ldap.server/dc=my_dc?uid?sub?(|(description=*admin*)(description=*options*));'
  - 'binddn "cn=cn_auth,dc=my_dc";'
  - 'binddn_passwd ***password***;'
  - 'group_attribute_is_dn on;'
  - 'require valid_user;'
  - 'satisfy any;'
  - '}'
