### PR TITLE
ensure => file is deprecated on concat::fragment

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -281,7 +281,7 @@ class nginx::config(
   }
 
   file { "${conf_dir}/nginx.conf":
-    ensure  => file,
+    ensure  => present,
     content => template($conf_template),
   }
 

--- a/manifests/resource/geo.pp
+++ b/manifests/resource/geo.pp
@@ -75,11 +75,6 @@ define nginx::resource::geo (
 
   $root_group = $::nginx::config::root_group
 
-  $ensure_real = $ensure ? {
-    'absent' => 'absent',
-    default  => 'file',
-  }
-
   File {
     owner => 'root',
     group => $root_group,
@@ -87,7 +82,7 @@ define nginx::resource::geo (
   }
 
   file { "${::nginx::config::conf_dir}/conf.d/${name}-geo.conf":
-    ensure  => $ensure_real,
+    ensure  => $ensure,
     content => template('nginx/conf.d/geo.erb'),
     notify  => Class['::nginx::service'],
   }

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -312,12 +312,6 @@ define nginx::resource::location (
     fail('$priority must be in the range 401-899.')
   }
 
-  # # Shared Variables
-  $ensure_real = $ensure ? {
-    'absent' => absent,
-    default  => file,
-  }
-
   ## Check for various error conditions
   if ($vhost == undef) {
     fail('Cannot create a location reference without attaching to a virtual host')
@@ -379,7 +373,7 @@ define nginx::resource::location (
   $location_md5 = md5($location)
   if ($ssl_only != true) {
     concat::fragment { "${vhost_sanitized}-${priority}-${location_md5}":
-      ensure  => $ensure_real,
+      ensure  => $ensure,
       target  => $config_file,
       content => join([
         template('nginx/vhost/location_header.erb'),
@@ -395,7 +389,7 @@ define nginx::resource::location (
     $ssl_priority = $priority + 300
 
     concat::fragment { "${vhost_sanitized}-${ssl_priority}-${location_md5}-ssl":
-      ensure  => $ensure_real,
+      ensure  => $ensure,
       target  => $config_file,
       content => join([
         template('nginx/vhost/location_header.erb'),

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -43,7 +43,7 @@ describe 'nginx::config' do
         )}
         it { is_expected.to contain_file('/etc/nginx/sites-enabled/default').with_ensure('absent') }
         it { is_expected.to contain_file("/etc/nginx/nginx.conf").with(
-          :ensure => 'file',
+          :ensure => 'present',
           :owner => 'root',
           :group => 'root',
           :mode => '0644'

--- a/spec/defines/resource_geo_spec.rb
+++ b/spec/defines/resource_geo_spec.rb
@@ -32,7 +32,7 @@ describe 'nginx::resource::geo' do
           'owner'   => 'root',
           'group'   => 'root',
           'mode'    => '0644',
-          'ensure'  => 'file',
+          'ensure'  => 'present',
           'content' => /geo \$#{title}/,
         }
       )}


### PR DESCRIPTION
syslog:

```
(Scope(Concat::Fragment[6666cd76f96956469e7be39d750cc7d9])) Passing a value other than 'present' or 'absent' as the $ensure parameter to concat::fragment is deprecated.  If you want to use the content of a file as a fragment please use the $source parameter.
```