### PR TITLE
Supress warnings with concat 2.x

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -379,7 +379,6 @@ define nginx::resource::location (
   $location_md5 = md5($location)
   if ($ssl_only != true) {
     concat::fragment { "${vhost_sanitized}-${priority}-${location_md5}":
-      ensure  => $ensure_real,
       target  => $config_file,
       content => join([
         template('nginx/vhost/location_header.erb'),
@@ -395,7 +394,6 @@ define nginx::resource::location (
     $ssl_priority = $priority + 300
 
     concat::fragment { "${vhost_sanitized}-${ssl_priority}-${location_md5}-ssl":
-      ensure  => $ensure_real,
       target  => $config_file,
       content => join([
         template('nginx/vhost/location_header.erb'),

--- a/manifests/resource/upstream/member.pp
+++ b/manifests/resource/upstream/member.pp
@@ -52,7 +52,6 @@ define nginx::resource::upstream::member (
 
   # Uses: $server, $port, $upstream_fail_timeout
   concat::fragment { "${upstream}_upstream_member_${name}":
-    ensure  => $ensure_real,
     target  => "${::nginx::config::conf_dir}/conf.d/${upstream}-upstream.conf",
     order   => 40,
     content => template('nginx/conf.d/upstream_member.erb'),


### PR DESCRIPTION
>Warning: Scope(Concat::Fragment[fqdn-500-6666cd76f96956469e7be39d750cc7d9]): The $ensure parameter to concat::fragment is deprecated and has no effect.

Resolves this error when using puppetlabs-concat 2.x

Closes #759