### PR TITLE
travis: enable bundler caching in builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ branches:
   - gh-pages
 sudo: false
 language: ruby
+cache: bundler
 script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake spec SPEC_OPTS='--format documentation'"
 bundler_args: --without rake
 matrix:


### PR DESCRIPTION
From https://docs.travis-ci.com/user/caching:

> On Ruby and Objective-C projects, installing dependencies via Bundler can make up a large portion of the build duration. Caching the bundle between builds drastically reduces the time a build takes to run.