### PR TITLE
Allow removal of gzip_types from the config

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -60,7 +60,7 @@ class nginx::config(
   $gzip_min_length                = 20,
   $gzip_http_version              = 1.1,
   $gzip_proxied                   = 'off',
-  $gzip_types                     = 'text/html',
+  $gzip_types                     = undef,
   $gzip_vary                      = 'off',
   $http_cfg_append                = false,
   $http_tcp_nodelay               = 'on',

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -74,7 +74,9 @@ http {
 <% if @gzip_proxied -%>
   gzip_proxied      <%= @gzip_proxied %>;
 <% end -%>
+<% if @gzip_types -%>
   gzip_types        <%= @gzip_types.kind_of?(Array) ? @gzip_types.join(' ') : @gzip_types %>;
+<% end -%>
   gzip_vary         <%= @gzip_vary %>;
 <% end -%>
 


### PR DESCRIPTION
The current default value is not ideal, as 'text/html' is always included whether specified in the config or not. If it's specified, nginx shows a warning on start up.

Fixes #748 