### PR TITLE
Adjusting Streamhosts implementation

### DIFF
--- a/manifests/resource/streamhost.pp
+++ b/manifests/resource/streamhost.pp
@@ -112,6 +112,17 @@ define nginx::resource::streamhost (
     'absent' => absent,
     default  => 'link',
   }
+  
+  file {
+    default:
+      ensure  => directory,
+      mode    => '0755',
+    ; 
+    "${streamhost_dir}":
+    ;
+    "${streamhost_enable_dir}":
+    ;
+  }
 
   $name_sanitized = regsubst($name, ' ', '_', 'G')
   $config_file = "${streamhost_dir}/${name_sanitized}.conf"

--- a/manifests/resource/streamhost.pp
+++ b/manifests/resource/streamhost.pp
@@ -113,15 +113,11 @@ define nginx::resource::streamhost (
     default  => 'link',
   }
   
-  file {
-    default:
+  file {[$streamhost_dir, $streamhost_enable_dir]:
       ensure  => directory,
-      mode    => '0755',
-    ; 
-    "${streamhost_dir}":
-    ;
-    "${streamhost_enable_dir}":
-    ;
+      owner   => $owner,
+      group   => $group,
+      mode    => $mode,
   }
 
   $name_sanitized = regsubst($name, ' ', '_', 'G')
@@ -132,8 +128,8 @@ define nginx::resource::streamhost (
       'absent' => absent,
       default  => 'file',
       require  => [
-        File["${streamhost_dir}"],
-        File["${streamhost_enable_dir}"],
+        File[$streamhost_dir],
+        File[$streamhost_enable_dir],
       ],
     },
     notify => Class['::nginx::service'],

--- a/manifests/resource/streamhost.pp
+++ b/manifests/resource/streamhost.pp
@@ -131,6 +131,10 @@ define nginx::resource::streamhost (
     ensure => $ensure ? {
       'absent' => absent,
       default  => 'file',
+      require  => [
+        File["${streamhost_dir}"],
+        File["${streamhost_enable_dir}"],
+      ],
     },
     notify => Class['::nginx::service'],
     owner  => $owner,

--- a/manifests/resource/streamhost.pp
+++ b/manifests/resource/streamhost.pp
@@ -114,10 +114,10 @@ define nginx::resource::streamhost (
   }
   
   file {[$streamhost_dir, $streamhost_enable_dir]:
-      ensure  => directory,
-      owner   => $owner,
-      group   => $group,
-      mode    => $mode,
+    ensure  => directory,
+    owner   => $owner,
+    group   => $group,
+    mode    => $mode,
   }
 
   $name_sanitized = regsubst($name, ' ', '_', 'G')

--- a/manifests/resource/streamhost.pp
+++ b/manifests/resource/streamhost.pp
@@ -114,10 +114,10 @@ define nginx::resource::streamhost (
   }
   
   file {[$streamhost_dir, $streamhost_enable_dir]:
-    ensure  => directory,
-    owner   => $owner,
-    group   => $group,
-    mode    => $mode,
+    ensure => directory,
+    owner  => $owner,
+    group  => $group,
+    mode   => $mode,
   }
 
   $name_sanitized = regsubst($name, ' ', '_', 'G')

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -156,5 +156,6 @@ mail {
 <% if @stream -%>
 stream {
   include <%= @conf_dir %>/conf.stream.d/*.conf;
+  include <%= @conf_dir %>/streams-enabled/*.conf;
 }
 <% end -%>

--- a/templates/streamhost/streamhost.erb
+++ b/templates/streamhost/streamhost.erb
@@ -17,7 +17,6 @@ server {
   listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
   <%- end -%>
 <%- end -%>
-  server_name           <%= @server_name.join(" ") %>;
 
   <% Array(@raw_prepend).each do |line| -%>
     <%= line %>


### PR DESCRIPTION
There were issues with the streamhosts implementation for TCP load balancing. Changes made to support successful implementation of a stream host within NGINX configurations:

1) added "include <%= @conf_dir %>/streams-enabled/.conf;" to stream {} section of nginx.conf.erb. In order to enable nginx to listen on the defined TCP port, the stream{} configuration needs to include the /etc/nginx/streams-enabled/.conf files.

2) Removed 'server_name' from streamhost.erb template. The 'server_name' parameter is not valid for a stream host implementation. Removed line 20: server_name <%= @server_name.join(" ") %>;

3) nginx::resource::streamhost.pp does not ensure that the /etc/nginx/streams-enabled and /etc/nginx/streams-available directories exist before creating the stream host files. Added a file resource to ensure these directories are created, and adjusted the file creation resource to require this resource when creating the files.