### PR TITLE
Add support for multiple 'proxy_cache_valid' directives

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -296,7 +296,7 @@ define nginx::resource::location (
     validate_string($proxy_cache_use_stale)
   }
   if ($proxy_cache_valid != false) {
-    validate_string($proxy_cache_valid)
+    validate_slength(any2array($proxy_cache_valid),12,1)
   }
   if ($proxy_method != undef) {
     validate_string($proxy_method)

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -296,7 +296,9 @@ define nginx::resource::location (
     validate_string($proxy_cache_use_stale)
   }
   if ($proxy_cache_valid != false) {
-    validate_slength(any2array($proxy_cache_valid),12,1)
+    if !(is_array($proxy_cache_valid) or is_string($proxy_cache_valid)) {
+      fail('$proxy_cache_valid must be a string or an array or false.')
+    }
   }
   if ($proxy_method != undef) {
     validate_string($proxy_method)

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -372,7 +372,7 @@ define nginx::resource::vhost (
     validate_string($proxy_cache_use_stale)
   }
   if ($proxy_cache_valid != false) {
-    validate_string($proxy_cache_valid)
+    validate_slength(any2array($proxy_cache_valid),12,1)
   }
   if ($proxy_method != undef) {
     validate_string($proxy_method)

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -372,7 +372,9 @@ define nginx::resource::vhost (
     validate_string($proxy_cache_use_stale)
   }
   if ($proxy_cache_valid != false) {
-    validate_slength(any2array($proxy_cache_valid),12,1)
+    if !(is_array($proxy_cache_valid) or is_string($proxy_cache_valid)) {
+      fail('$proxy_cache_valid must be a string or an array or false.')
+    }
   }
   if ($proxy_method != undef) {
     validate_string($proxy_method)

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -599,10 +599,19 @@ describe 'nginx::resource::location' do
           :notmatch => /proxy_cache_valid\b/
         },
         {
-          :title => 'should set proxy_cache_valid',
+          :title => 'should set proxy_cache_valid when string',
           :attr  => 'proxy_cache_valid',
           :value => 'value',
           :match => /^\s+proxy_cache_valid\s+value;/,
+        },
+        {
+          :title => 'should set proxy_cache_valid when array of strings',
+          :attr  => 'proxy_cache_valid',
+          :value => ['value1','value2'],
+          :match => [
+	    /^\s+proxy_cache_valid\s+value1;/,
+	    /^\s+proxy_cache_valid\s+value2;/,
+	  ]
         },
         {
           :title    => 'should not set proxy_cache',

--- a/templates/vhost/locations/proxy.erb
+++ b/templates/vhost/locations/proxy.erb
@@ -16,8 +16,10 @@
 <% if @proxy_cache -%>
     proxy_cache           <%= @proxy_cache %>;
 <% end -%>
-<% if @proxy_cache_valid -%>
-    proxy_cache_valid     <%= @proxy_cache_valid %>;
+<% if @proxy_cache_valid && Array(@proxy_cache_valid).size > 0 -%>
+    <%- Array(@proxy_cache_valid).each do |line| -%>
+    proxy_cache_valid     <%= line %>;
+    <%- end -%>
 <% end -%>
 <% if @proxy_cache_use_stale -%>
     proxy_cache_use_stale   <%= @proxy_cache_use_stale %>;


### PR DESCRIPTION
Nginx supports multiple proxy_cache_valid directives.
This allows to specify a different caching time for different response codes.
(http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_valid)

This PR adds the possibility to specify an array of strings for the 'proxy_cache_valid' attribute, while preserving backwards compatibility by still accepting a string (which is the expected behavior today). 

Also, a unit test has been added that covers the new behavior, hence both the current and the new behavior is tested. 