### PR TITLE
add support to auth_ldap module

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -66,6 +66,38 @@ nginx::resource::vhost { 'rack.puppetlabs.com':
 }
 ```
 
+### Use ldap authentication
+
+  * nginx must be compiled with [auth_ldap](https://github.com/kvspb/nginx-auth-ldap) module
+  * enable caching for solving [segmentfault](https://github.com/kvspb/nginx-auth-ldap/issues/8) problems
+
+```puppet
+
+nginx::config::auth_ldap_cache_enabled: 'on'
+nginx::config::auth_ldap_cache_expiration_time: '3600'
+nginx::config::auth_ldap_cache_size: '1000'
+
+# add auth_ldap support to a vhost
+# auth_ldap_servers must match the resource title from nginx::module::auth_ldap
+nginx::nginx_vhosts:
+    auth_ldap: 'Authentication Required'
+    auth_ldap_servers:
+      - 'dc01'
+
+# ldap configurations
+nginx::module::auth_ldap:
+  'dc01':
+    server: 'dc01'
+    url: 'ldap://dc01.example.com:389/OU=Users,DC=example,DC=com?sAMAccountName?sub?(objectClass=person)'
+    binddn: 'CN=bob,OU=Users,DC=example,DC=com'
+    binddn_passwd: 'strongpassword'
+    group_attribute: 'member'
+    group_attribute_is_dn: 'on'
+    satisfy: 'any'
+    require_group_dn:
+      - 'CN=it,OU=Groups,DC=example,DC=com'
+```
+
 ### Add a smtp proxy
 
 ```puppet

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -45,6 +45,9 @@ class nginx::config(
   ### START Nginx Configuration ###
   $accept_mutex                   = 'on',
   $accept_mutex_delay             = '500ms',
+  $auth_ldap_cache_enabled         = undef,
+  $auth_ldap_cache_expiration_time = undef,
+  $auth_ldap_cache_size            = undef,
   $client_body_buffer_size        = '128k',
   $client_max_body_size           = '10m',
   $events_use                     = false,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -296,6 +296,12 @@ class nginx (
     service_flags     => $service_flags,
   }
 
+  $module_auth_ldap = hiera_hash('nginx::module::auth_ldap', {})
+  if $module_auth_ldap {
+    validate_hash($module_auth_ldap)
+    create_resources('nginx::module::auth_ldap', $module_auth_ldap)
+  }
+
   create_resources('nginx::resource::upstream', $nginx_upstreams)
   create_resources('nginx::resource::vhost', $nginx_vhosts, $nginx_vhosts_defaults)
   create_resources('nginx::resource::location', $nginx_locations)

--- a/manifests/module/auth_ldap.pp
+++ b/manifests/module/auth_ldap.pp
@@ -1,0 +1,34 @@
+# define: nginx::module::auth_ldap
+#
+# This definition creates a new location entry within a virtual host
+#
+define nginx::module::auth_ldap (
+  $server                = 'dc01',
+  $url                   = 'ldap://dc01.example.com:389/OU=Users,DC=example,DC=com?sAMAccountName?sub?(objectClass=person)',
+  $binddn                = undef,
+  $binddn_passwd         = undef,
+  $group_attribute       = 'member',
+  $group_attribute_is_dn = 'on',
+  $satisfy               = 'any',
+  $require_group_dn      = [],
+  $require_user_dn       = [],
+) {
+
+  include nginx
+
+  $_root_group      = $::nginx::config::root_group
+  $_auth_ldap_conf  = "${::nginx::config::conf_dir}/conf.d/${server}.conf"
+
+  concat { $_auth_ldap_conf:
+    owner  => 'root',
+    group  => $_root_group,
+    mode   => '0644',
+    path   => $_auth_ldap_conf,
+    notify => Class['::nginx::service'],
+  }
+  concat::fragment { "nginx auth_ldap module: ${server}":
+    target  => $_auth_ldap_conf,
+    content => template('nginx/module/auth_ldap.erb'),
+  }
+
+}

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -183,6 +183,8 @@ define nginx::resource::location (
   $priority             = 500,
   $mp4             = false,
   $flv             = false,
+  $auth_ldap            = undef,
+  $auth_ldap_servers    = [],
 ) {
 
   $root_group = $::nginx::config::root_group

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -271,7 +271,9 @@ define nginx::resource::vhost (
   $mode                         = $::nginx::config::global_mode,
   $maintenance                  = false,
   $maintenance_value            = 'return 503',
-  $locations                    = {}
+  $locations                    = {},
+  $auth_ldap                    = undef,
+  $auth_ldap_servers            = [],
 ) {
 
   validate_re($ensure, '^(present|absent)$',
@@ -568,6 +570,8 @@ define nginx::resource::vhost (
     # Create the default location reference for the vHost
     nginx::resource::location {"${name_sanitized}-default":
       ensure                      => $ensure,
+      auth_ldap                   => $auth_ldap,
+      auth_ldap_servers           => $auth_ldap_servers,
       vhost                       => $name_sanitized,
       ssl                         => $ssl,
       ssl_only                    => $ssl_only,

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -130,6 +130,15 @@ http {
 <% elsif @proxy_cache_path -%>
   proxy_cache_path        <%= @proxy_cache_path %> levels=<%= @proxy_cache_levels %> keys_zone=<%= @proxy_cache_keys_zone %> max_size=<%= @proxy_cache_max_size %> inactive=<%= @proxy_cache_inactive %>;
 <% end -%>
+<% if @auth_ldap_cache_enabled -%>
+  auth_ldap_cache_enabled         <%= @auth_ldap_cache_enabled %>;
+<% end -%>
+<% if @auth_ldap_cache_expiration_time -%>
+  auth_ldap_cache_expiration_time <%= @auth_ldap_cache_expiration_time %>;
+<% end -%>
+<% if @auth_ldap_cache_size -%>
+  auth_ldap_cache_size            <%= @auth_ldap_cache_size %>;
+<% end -%>
 <% if @fastcgi_cache_path -%>
   fastcgi_cache_path    	<%= @fastcgi_cache_path %> levels=<%= @fastcgi_cache_levels %> keys_zone=<%= @fastcgi_cache_keys_zone %> max_size=<%= @fastcgi_cache_max_size %> inactive=<%= @fastcgi_cache_inactive %>;
 <% end -%>

--- a/templates/module/auth_ldap.erb
+++ b/templates/module/auth_ldap.erb
@@ -1,0 +1,30 @@
+ldap_server <%= @server %> {
+      url "<%= @url %>";
+
+      binddn "<%= @binddn %>";
+      binddn_passwd <%= @binddn_passwd %>;
+
+      # group attribute name which contains member object
+      group_attribute <%= @group_attribute %>;
+
+      # search for full DN in member object
+      group_attribute_is_dn <%= @group_attribute_is_dn %>;
+
+      # matching algorithm (any / all)
+      satisfy <%= @satisfy %>;
+
+<%- if @require_group_dn -%>
+<% @require_group_dn.each do | group | -%>
+      require group "<%= group %>";
+<% end -%>
+<%- end -%>
+
+    <%- if @require_group_dn -%>
+      # require 'valid_user' cannot be used together with 'user' as valid user is a superset
+      # require valid_user;
+      <% @require_user_dn.each do | user | -%>
+      require user "<%= user %>";
+      <% end -%>
+    <%- end -%>
+
+}

--- a/templates/vhost/location_header.erb
+++ b/templates/vhost/location_header.erb
@@ -22,6 +22,14 @@
     deny <%= deny_rule %>;
     <%- end -%>
 <% end -%>
+<% if @auth_ldap -%>
+    auth_ldap          "<%= @auth_ldap %>";
+<% end -%>
+<%- if @auth_ldap_servers -%>
+<% @auth_ldap_servers.each do | auth_ldap_server | -%>
+    auth_ldap_servers  "<%= auth_ldap_server %>";
+<% end -%>
+<%- end -%>
 <% if @auth_basic -%>
     auth_basic           "<%= @auth_basic %>";
 <%- end %>


### PR DESCRIPTION
In order to authenticate against a ldap server, nginx must be recompiled with auth_ldap module.

```puppet

nginx::config::auth_ldap_cache_enabled: 'on'
nginx::config::auth_ldap_cache_expiration_time: '3600'
nginx::config::auth_ldap_cache_size: '1000'

# add auth_ldap support to a vhost
# auth_ldap_servers must match the resource title from nginx::module::auth_ldap
nginx::nginx_vhosts:
    auth_ldap: 'Authentication Required'
    auth_ldap_servers:
      - 'dc01'

# ldap configurations
nginx::module::auth_ldap:
  'dc01':
    server: 'dc01'
    url: 'ldap://dc01.example.com:389/OU=Users,DC=example,DC=com?sAMAccountName?sub?(objectClass=person)'
    binddn: 'CN=bob,OU=Users,DC=example,DC=com'
    binddn_passwd: 'strongpassword'
    group_attribute: 'member'
    group_attribute_is_dn: 'on'
    satisfy: 'any'
    require_group_dn:
      - 'CN=it,OU=Groups,DC=example,DC=com'
```

If you like the changes I could implement some rspec tests