### PR TITLE
Make 'include fastcgi_params' optional

### DIFF
--- a/templates/vhost/locations/fastcgi.erb
+++ b/templates/vhost/locations/fastcgi.erb
@@ -1,7 +1,9 @@
 <% if defined? @www_root -%>
     root          <%= @www_root %>;
 <% end -%>
+<% if @fastcgi_params -%>
     include       <%= @fastcgi_params %>;
+<% end -%>
 <% if @try_files -%>
     try_files    <% @try_files.each do |try| -%> <%= try %><% end -%>;
 <% end -%>


### PR DESCRIPTION
Proposed to make 'fastcgi_params' within 'include' configureable - be able to not add it to the location, if 'fastcgi_params' was not set.