### PR TITLE
Support for proxy_hide_header directive.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -93,6 +93,7 @@ class nginx::config(
     'X-Real-IP $remote_addr',
     'X-Forwarded-For $proxy_add_x_forwarded_for',
   ],
+  $proxy_hide_header              = [],
   $sendfile                       = 'on',
   $server_tokens                  = 'on',
   $spdy                           = 'off',
@@ -121,6 +122,7 @@ class nginx::config(
   }
   validate_string($multi_accept)
   validate_array($proxy_set_header)
+  validate_array($proxy_hide_header)
   if ($proxy_http_version != undef) {
     validate_string($proxy_http_version)
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,6 +61,7 @@ class nginx (
   $proxy_redirect                 = undef,
   $proxy_send_timeout             = undef,
   $proxy_set_header               = undef,
+  $proxy_hide_header              = undef,
   $sendfile                       = undef,
   $server_tokens                  = undef,
   $spdy                           = undef,
@@ -184,6 +185,7 @@ class nginx (
         $proxy_redirect or
         $proxy_send_timeout or
         $proxy_set_header or
+        $proxy_hide_header or
         $proxy_temp_path or
         $run_dir or
         $sendfile or
@@ -265,6 +267,7 @@ class nginx (
       proxy_redirect                 => $proxy_redirect,
       proxy_send_timeout             => $proxy_send_timeout,
       proxy_set_header               => $proxy_set_header,
+      proxy_hide_header              => $proxy_hide_header,
       proxy_temp_path                => $proxy_temp_path,
       run_dir                        => $run_dir,
       sendfile                       => $sendfile,

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -31,6 +31,7 @@
 #   [*proxy_connect_timeout*] - Override the default the proxy connect timeout
 #     value of 90 seconds
 #   [*proxy_set_header*]     - Array of vhost headers to set
+#   [*proxy_hide_header*]    - Array of vhost headers to hide
 #   [*fastcgi*]              - location of fastcgi (host:port)
 #   [*fastcgi_param*]        - Set additional custom fastcgi_params
 #   [*fastcgi_params*]       - optional alternative fastcgi_params file to use
@@ -147,6 +148,7 @@ define nginx::resource::location (
   $proxy_read_timeout   = $::nginx::config::proxy_read_timeout,
   $proxy_connect_timeout = $::nginx::config::proxy_connect_timeout,
   $proxy_set_header     = $::nginx::config::proxy_set_header,
+  $proxy_hide_header    = $::nginx::config::proxy_hide_header,
   $fastcgi              = undef,
   $fastcgi_param        = undef,
   $fastcgi_params       = "${::nginx::config::conf_dir}/fastcgi_params",
@@ -216,6 +218,7 @@ define nginx::resource::location (
   validate_string($proxy_read_timeout)
   validate_string($proxy_connect_timeout)
   validate_array($proxy_set_header)
+  validate_array($proxy_hide_header)
   if ($fastcgi != undef) {
     validate_string($fastcgi)
   }

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -214,6 +214,7 @@ define nginx::resource::vhost (
   $proxy_read_timeout           = $::nginx::config::proxy_read_timeout,
   $proxy_connect_timeout        = $::nginx::config::proxy_connect_timeout,
   $proxy_set_header             = $::nginx::config::proxy_set_header,
+  $proxy_hide_header            = $::nginx::config::proxy_hide_header,
   $proxy_cache                  = false,
   $proxy_cache_key              = undef,
   $proxy_cache_use_stale        = undef,
@@ -367,6 +368,7 @@ define nginx::resource::vhost (
     validate_string($proxy_redirect)
   }
   validate_array($proxy_set_header)
+  validate_array($proxy_hide_header)
   if ($proxy_cache != false) {
     validate_string($proxy_cache)
   }
@@ -592,6 +594,7 @@ define nginx::resource::vhost (
       proxy_cache_valid           => $proxy_cache_valid,
       proxy_method                => $proxy_method,
       proxy_set_header            => $proxy_set_header,
+      proxy_hide_header           => $proxy_hide_header,
       proxy_set_body              => $proxy_set_body,
       fastcgi                     => $fastcgi,
       fastcgi_params              => $fastcgi_params,

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -476,12 +476,21 @@ describe 'nginx::config' do
           :notmatch => 'proxy_http_version',
         },
         {
-          :title => 'should contain ordered appended directives',
+          :title => 'should contain ordered appended proxy_set_header directives',
           :attr  => 'proxy_set_header',
           :value => ['header1','header2'],
           :match => [
             '  proxy_set_header        header1;',
             '  proxy_set_header        header2;',
+          ],
+        },
+        {
+          :title => 'should contain ordered appended proxy_hide_header directives',
+          :attr  => 'proxy_hide_header',
+          :value => ['header1','header2'],
+          :match => [
+            '  proxy_hide_header        header1;',
+            '  proxy_hide_header        header2;',
           ],
         },
         {

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -665,6 +665,15 @@ describe 'nginx::resource::location' do
           ]
         },
         {
+          :title => 'should hide proxy headers',
+          :attr  => 'proxy_hide_header',
+          :value => [ 'X-TestHeader1 value1', 'X-TestHeader2 value2' ],
+          :match => [
+            /^\s+proxy_hide_header\s+X-TestHeader1 value1;/,
+            /^\s+proxy_hide_header\s+X-TestHeader2 value2;/,
+          ]
+        },
+        {
           :title => 'should set proxy_method',
           :attr  => 'proxy_method',
           :value => 'value',

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -120,6 +120,9 @@ http {
 <% @proxy_set_header.each do |header| -%>
   proxy_set_header        <%= header %>;
 <% end -%>
+<% @proxy_hide_header.each do |header| -%>
+  proxy_hide_header        <%= header %>;
+<% end -%>
 <% if @proxy_headers_hash_bucket_size -%>
   proxy_headers_hash_bucket_size <%= @proxy_headers_hash_bucket_size %>;
 <% end -%>

--- a/templates/vhost/locations/proxy.erb
+++ b/templates/vhost/locations/proxy.erb
@@ -13,6 +13,11 @@
     proxy_set_header      <%= header %>;
     <%- end -%>
 <% end -%>
+<% unless @proxy_hide_header.nil? -%>
+    <%- @proxy_hide_header.each do |header| -%>
+    proxy_hide_header      <%= header %>;
+    <%- end -%>
+<% end -%>
 <% if @proxy_cache -%>
     proxy_cache           <%= @proxy_cache %>;
 <% end -%>


### PR DESCRIPTION
I need this to hide X-Frame-Options for a single location block.

From nginx docs about proxy_hide_header:
By default, nginx does not pass the header fields “Date”, “Server”,
“X-Pad”, and “X-Accel-...” from the response of a proxied server to a
client. The proxy_hide_header directive sets additional fields that will
not be passed.