### PR TITLE
make fact work on old nginx as well

### DIFF
--- a/lib/facter/nginx_version.rb
+++ b/lib/facter/nginx_version.rb
@@ -2,7 +2,7 @@ Facter.add(:nginx_version) do
   setcode do
     if Facter::Util::Resolution.which('nginx')
       nginx_version = Facter::Util::Resolution.exec('nginx -v 2>&1')
-      %r{^nginx version: nginx\/([\w\.]+)}.match(nginx_version)[1]
+      %r{nginx version: nginx\/([\w\.]+)}.match(nginx_version)[1]
     end
   end
 end


### PR DESCRIPTION
CentOS 7 (default fact works): nginx version: nginx/1.10.0
CentOS 6: nginx: nginx version: nginx/1.0.0

Fixes #799