### PR TITLE
Confine nginx_version fact

### DIFF
--- a/lib/facter/nginx_version.rb
+++ b/lib/facter/nginx_version.rb
@@ -1,6 +1,6 @@
 Facter.add(:nginx_version) do
   setcode do
-    if Facter::Util::Resolution.which('nginx')
+    if Facter.value('kernel') != 'windows' && Facter::Util::Resolution.which('nginx')
       nginx_version = Facter::Util::Resolution.exec('nginx -v 2>&1')
       %r{^nginx version: nginx\/([\w\.]+)}.match(nginx_version)[1]
     end


### PR DESCRIPTION
If this fact is not confined it will display a dialog on Windows which requires interaction.  If puppet runs silently, it will hang.

Fixes #814