### PR TITLE
Add manage_service parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -112,6 +112,7 @@ class nginx (
   $service_flags                  = undef,
   $service_restart                = '/etc/init.d/nginx reload',
   $service_name                   = undef,
+  $service_manage                 = true,
   ### END Service Configuration ###
 
   ### START Hiera Lookups ###
@@ -294,6 +295,7 @@ class nginx (
     service_restart   => $service_restart,
     service_name      => $service_name,
     service_flags     => $service_flags,
+    service_manage    => $service_manage,
   }
 
   create_resources('nginx::resource::upstream', $nginx_upstreams)

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -19,6 +19,7 @@ class nginx::service(
   $service_ensure    = $::nginx::service_ensure,
   $service_name      = 'nginx',
   $service_flags     = undef,
+  $service_manage    = true,
 ) {
 
   $service_enable = $service_ensure ? {
@@ -35,24 +36,26 @@ class nginx::service(
     $service_ensure_real = $service_ensure
   }
 
-  case $::osfamily {
-    'OpenBSD': {
-      service { 'nginx':
-        ensure     => $service_ensure_real,
-        name       => $service_name,
-        enable     => $service_enable,
-        flags      => $service_flags,
-        hasstatus  => true,
-        hasrestart => true,
+  if $service_manage {
+    case $::osfamily {
+      'OpenBSD': {
+        service { 'nginx':
+          ensure     => $service_ensure_real,
+          name       => $service_name,
+          enable     => $service_enable,
+          flags      => $service_flags,
+          hasstatus  => true,
+          hasrestart => true,
+        }
       }
-    }
-    default: {
-      service { 'nginx':
-        ensure     => $service_ensure_real,
-        name       => $service_name,
-        enable     => $service_enable,
-        hasstatus  => true,
-        hasrestart => true,
+      default: {
+        service { 'nginx':
+          ensure     => $service_ensure_real,
+          name       => $service_name,
+          enable     => $service_enable,
+          hasstatus  => true,
+          hasrestart => true,
+        }
       }
     }
   }

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -6,6 +6,7 @@ describe 'nginx::service' do
       :service_restart => '/etc/init.d/nginx reload',
       :service_ensure => 'running',
       :service_name => 'nginx',
+      :service_manage => true,
   } end
 
   context "using default parameters" do
@@ -46,5 +47,12 @@ describe 'nginx::service' do
       :service_name => 'nginx14',
     } end
     it { is_expected.to contain_service('nginx').with_name('nginx14') }
+  end
+
+  describe "when service_manage => false" do
+    let :params do {
+      :service_manage => false,
+    } end
+    it { is_expected.not_to contain_service('nginx') }
   end
 end


### PR DESCRIPTION
Puppet managing the service is not desirable in every environment.

Use `?w=1` to omit whitespace changes.