### PR TITLE
travis: enhance the configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,16 @@ matrix:
   include:
     - rvm: 1.9.3
       env: PUPPET_GEM_VERSION="~> 3.0"
-    - rvm: 2.0.0
+    - rvm: 2.1.10
       env: PUPPET_GEM_VERSION="~> 3.0"
-    - rvm: 2.1.0
-      env: PUPPET_GEM_VERSION="~> 3.0"
-    - rvm: 2.1.0
+    - rvm: 2.1.10
+      env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
+    - rvm: 2.1.10
       env: PUPPET_GEM_VERSION="~> 4.0"
+    - rvm: 2.1.10
+      env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
+  allow_failures:
+    - rvm: 2.1.10
+      env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
 notifications:
   email: false


### PR DESCRIPTION
* Test Puppet 3.0 on Ruby 1.9.3, everything else on latest Ruby 2.1.10
* Test Puppet 3.0 on future parser again
* Test with strict variables, but don't fail the build if it fails (yet!)