### PR TITLE
Enhance module metadata

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ group :rake do
   gem 'puppet-lint',            '~> 2.0', :require => false
   gem 'puppet-blacksmith',                :require => false
   gem 'rake',                             :require => false
+  gem 'metadata-json-lint',               :require => false
 end
 
 group :system_tests do

--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "puppet",
-      "version_requirement": "3.x"
+      "version_requirement": ">= 3.0.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -48,6 +48,9 @@
     {
       "operatingsystem": "Solaris"
     },
+    { "operatingsystem": "AIX" },
+    { "operatingsystem": "FreeBSD" },
+    { "operatingsystem": "NetBSD" },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [


### PR DESCRIPTION
claim support for puppet 4, AIX, FreeBSD & NetBSD
add enable metadata-json-lint gem so syntax is checked in future