### PR TITLE
Pin rake to last supported version for ruby 1.8.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ group :rake do
   gem 'rspec-puppet',           '~> 2.3', :require => false
   gem 'puppet-lint',            '~> 2.0', :require => false
   gem 'puppet-blacksmith',                :require => false
-  gem 'rake',                             :require => false
+  gem 'rake',                  '~> 10.5', :require => false
   gem 'metadata-json-lint',               :require => false
 end
 


### PR DESCRIPTION
The latest version of rake does not support ruby 1.8.7, so some of the tests were failing.  This pins rake to the last supported version: '10.5'.