### PR TITLE
Mitigation for US-CERT VU#797896

### DIFF
--- a/templates/vhost/fastcgi_params.erb
+++ b/templates/vhost/fastcgi_params.erb
@@ -25,3 +25,8 @@ fastcgi_param  HTTPS              $https;
 
 # PHP only, required if PHP was built with --enable-force-cgi-redirect
 fastcgi_param  REDIRECT_STATUS    200;
+
+# Workaround for US-CERT VU#797896. There appear to be no real reason
+# to forward the Proxy: header to FastCGI backends. We simply remove it
+# if it exists. Please see https://www.kb.cert.org/vuls/id/797896
+fastcgi_param  HTTP_PROXY         "";


### PR DESCRIPTION
US-CERT VU#797896 (and others) describes an attack where an end-user is capable of overriding the proxy setting for multiple FastCGI backends.

I propose we help mitigate this attack by removing the variable before reaching the backend as proposed by multiple vendors and industry players.

Sources:
https://www.kb.cert.org/vuls/id/797896
https://httpoxy.org/
https://www.nginx.com/blog/mitigating-the-httpoxy-vulnerability-with-nginx/

Relevant CVEs:
CVE-2016-5385: PHP
CVE-2016-5386: Go
CVE-2016-5387: Apache HTTP Server
CVE-2016-5388: Apache Tomcat
CVE-2016-1000109: HHVM
CVE-2016-1000110: Python
