### PR TITLE
gemfile: pin json_pure to 2.0.1 or lower on ruby 1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ group :system_tests do
   gem 'beaker',       :require => false
 end
 
+gem 'json_pure', '<=2.0.1', :require => false if RUBY_VERSION =~ /^1\./
+
 if puppetversion = ENV['PUPPET_GEM_VERSION']
   gem 'puppet', puppetversion, :require => false
 else


### PR DESCRIPTION
json_pure 2.0.2 requires ruby 2.0 or higher