### PR TITLE
Conditionally adding the packages if they are not added previously

### DIFF
--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -53,10 +53,9 @@ class nginx::package::debian(
           key      => '16378A33A6EF16762922526E561F9B9CAC40B2F7',
         }
 
-        package { ['apt-transport-https', 'ca-certificates']:
-          ensure => 'present',
-          before => Apt::Source['nginx'],
-        }
+        ensure_packages([ 'apt-transport-https', 'ca-certificates' ])
+
+        Apt::Source['nginx'] -> Package['apt-transport-https','ca-certificates']
 
         package { 'passenger':
           ensure  => 'present',


### PR DESCRIPTION
We faced the problem that when using the puppet-nginx module and managing ca-certificates on our own it will bring up problems only because of assigning the same resource twice.

(ensure_resources() would be nice to use but I didn't want to add additional dependencies)