### PR TITLE
add proxy_buffering parameter to location & vhost

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -81,6 +81,7 @@
 #   [*proxy_method*]         - If defined, overrides the HTTP method of the
 #     request to be passed to the backend.
 #   [*proxy_set_body*]       - If defined, sets the body passed to the backend.
+#   [*proxy_buffering*]      - If defined, sets the proxy_buffering to the passed value.
 #   [*auth_basic*]            - This directive includes testing name and password
 #     with HTTP Basic Authentication.
 #   [*auth_basic_user_file*]  - This directive sets the htpasswd filename for
@@ -179,6 +180,7 @@ define nginx::resource::location (
   $proxy_cache_valid    = false,
   $proxy_method         = undef,
   $proxy_set_body       = undef,
+  $proxy_buffering      = undef,
   $auth_basic           = undef,
   $auth_basic_user_file = undef,
   $rewrite_rules        = [],
@@ -308,6 +310,9 @@ define nginx::resource::location (
   }
   if ($proxy_set_body != undef) {
     validate_string($proxy_set_body)
+  }
+  if ($proxy_buffering != undef) {
+    validate_re($proxy_buffering, '^(on|off)$')
   }
   if ($auth_basic != undef) {
     validate_string($auth_basic)

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -42,6 +42,7 @@
 #   [*proxy_read_timeout*]  - Override the default the proxy read timeout value
 #     of 90 seconds
 #   [*proxy_redirect*]      - Override the default proxy_redirect value of off.
+#   [*proxy_buffering*]     - If defined, sets the proxy_buffering to the passed value.
 #   [*resolver*]            - Array: Configures name servers used to resolve
 #     names of upstream servers into addresses.
 #   [*fastcgi*]             - location of fastcgi (host:port)
@@ -227,6 +228,7 @@ define nginx::resource::vhost (
   $proxy_cache_valid            = false,
   $proxy_method                 = undef,
   $proxy_set_body               = undef,
+  $proxy_buffering              = undef,
   $resolver                     = [],
   $fastcgi                      = undef,
   $fastcgi_params               = "${::nginx::config::conf_dir}/fastcgi_params",
@@ -400,6 +402,9 @@ define nginx::resource::vhost (
   }
   if ($proxy_set_body != undef) {
     validate_string($proxy_set_body)
+  }
+  if ($proxy_buffering != undef) {
+    validate_re($proxy_buffering, '^(on|off)$')
   }
   validate_array($resolver)
   if ($fastcgi != undef) {
@@ -608,6 +613,7 @@ define nginx::resource::vhost (
       proxy_set_header            => $proxy_set_header,
       proxy_hide_header           => $proxy_hide_header,
       proxy_set_body              => $proxy_set_body,
+      proxy_buffering             => $proxy_buffering,
       fastcgi                     => $fastcgi,
       fastcgi_params              => $fastcgi_params,
       fastcgi_script              => $fastcgi_script,

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -693,6 +693,12 @@ describe 'nginx::resource::location' do
           :value => 'value',
           :match => %r'\s+proxy_set_body\s+value;',
         },
+        {
+          :title => 'should set proxy_buffering',
+          :attr  => 'proxy_buffering',
+          :value => 'on',
+          :match => %r'\s+proxy_buffering\s+on;',
+        },
       ].each do |param|
         context "when #{param[:attr]} is #{param[:value]}" do
           let :default_params do { :location => 'location', :proxy => 'proxy_value', :vhost => 'vhost1' } end

--- a/templates/vhost/locations/proxy.erb
+++ b/templates/vhost/locations/proxy.erb
@@ -8,6 +8,9 @@
 <% if @proxy_set_body -%>
     proxy_set_body        <%= @proxy_set_body %>;
 <% end -%>
+<% if @proxy_buffering -%>
+    proxy_buffering       <%= @proxy_buffering %>;
+<% end -%>
 <% unless @proxy_set_header.nil? -%>
     <%- @proxy_set_header.each do |header| -%>
     proxy_set_header      <%= header %>;


### PR DESCRIPTION
This allows us to configure nginx' [proxy_buffering](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering).
More specifically, it allows us to disable it, for the rare occasions
when this is needed.

Closes #840 
Closes #853 