### PR TITLE
Revert "pin rubocop and rubocop-rspec depending on Ruby version"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,6 @@ group :rake do
   gem 'puppet-blacksmith',                :require => false
   gem 'rake',                             :require => false
   gem 'metadata-json-lint',               :require => false
-  gem 'rubocop-rspec',          '~> 1.6', :require => false if RUBY_VERSION >= '2.2.0'
-  gem 'rubocop-rspec',          '1.5.0',  :require => false if RUBY_VERSION < '2.2.0'
-  gem 'rubocop',                '0.41.2', :require => false if RUBY_VERSION < '2.0.0'
 end
 
 group :system_tests do


### PR DESCRIPTION
Reverts jfryman/puppet-nginx#857

This is no longer necessary - it was added to work around a problem with puppetlabs_spec_helper 1.2.0. However that release was yanked, so this is no longer required.